### PR TITLE
Minor fixes to the PS1 screens

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -24,6 +24,7 @@
           <router-link to="/about">About{{'\xa0'}}/{{'\xa0'}}Contact</router-link>
         </b-col>
       </b-row>
+      <hr/>
     </div>
     <router-view/>
     <mq-layout :mq="['xs', 'sm']">

--- a/frontend/src/components/ConvertPs1DexDrive.vue
+++ b/frontend/src/components/ConvertPs1DexDrive.vue
@@ -40,8 +40,8 @@
         <b-col sm=12 md=5 align-self="start">
           <b-row no-gutters align-h="center" align-v="start">
             <b-col cols=12>
-              <b-jumbotron fluid :header-level="$mq | mq({ xs: 5, sm: 5, md: 5, lg: 5, xl: 4 })">
-                <template v-slot:header>Emulator/Raw</template>
+              <b-jumbotron fluid :header-level="$mq | mq({ xs: 5, sm: 5, md: 5, lg: 5, xl: 4 })" :class="$mq === 'md' ? 'fix-jumbotron' : ''">
+                <template v-slot:header>Individual saves</template>
               </b-jumbotron>
             </b-col>
           </b-row>
@@ -83,7 +83,7 @@
             Help: how do I&nbsp;<b-link href="https://github.com/ShendoXT/memcardrex/releases">copy files to and from my DexDrive</b-link>?
           </div>
           <div class="help">
-            Help: how do I copy save files to and from a PS1 memory card?<br><b-link href="http://ps2ulaunchelf.pbworks.com/w/page/19520134/FrontPage">PS2 + USB stick</b-link> or <b-link href="https://github.com/ShendoXT/memcardrex/releases">PS3 USB memory card adaptor</b-link> or <b-link href="https://github.com/ShendoXT/memcardrex/releases">DexDrive</b-link> or <b-link href="https://8bitmods.com/memcard-pro-for-playstation-1-smoke-black/">MemCard Pro</b-link>
+            Help: how do I copy individual save files to and from a PS1 memory card?<br><b-link href="http://ps2ulaunchelf.pbworks.com/w/page/19520134/FrontPage">PS2 + USB stick</b-link> or <b-link href="https://github.com/ShendoXT/memcardrex/releases">PS3 USB memory card adaptor</b-link> or <b-link href="https://github.com/ShendoXT/memcardrex/releases">DexDrive</b-link> or <b-link href="https://8bitmods.com/memcard-pro-for-playstation-1-smoke-black/">MemCard Pro</b-link>
           </div>
           <div class="help">
             Help: how do I <b-link href="https://www.google.com/search?q=ps2+mcboot+memory+card">run homebrew software on my PS2</b-link>?
@@ -103,6 +103,15 @@
 
 .help {
   margin-top: 1em;
+}
+
+/* We have so much text in our jumbotron that at the md size it wants to be vertically larger than the other one. So let's constrain it and move the text upwards insie it */
+.fix-jumbotron {
+  max-height: 11.5em;
+}
+
+.fix-jumbotron > div {
+  margin-top: -1em;
 }
 </style>
 

--- a/frontend/src/components/ConvertPs1DexDrive.vue
+++ b/frontend/src/components/ConvertPs1DexDrive.vue
@@ -56,6 +56,11 @@
               :leaveRoomForHelpIcon="false"
               :allowMultipleFiles="true"
             />
+            <file-list
+              :display="this.dexDriveSaveData !== null"
+              :files="this.dexDriveSaveData ? this.dexDriveSaveData.getSaveFiles() : []"
+              :enabled="false"
+            />
           </div>
         </b-col>
       </b-row>

--- a/frontend/src/components/ConvertPs1Psp.vue
+++ b/frontend/src/components/ConvertPs1Psp.vue
@@ -41,8 +41,8 @@
         <b-col sm=12 md=5 align-self="start">
           <b-row no-gutters align-h="center" align-v="start">
             <b-col cols=12>
-              <b-jumbotron fluid :header-level="$mq | mq({ xs: 5, sm: 5, md: 5, lg: 5, xl: 4 })">
-                <template v-slot:header>Emulator/Raw</template>
+              <b-jumbotron fluid :header-level="$mq | mq({ xs: 5, sm: 5, md: 5, lg: 5, xl: 4 })" :class="$mq === 'md' ? 'fix-jumbotron' : ''">
+                <template v-slot:header>Individual saves</template>
               </b-jumbotron>
             </b-col>
           </b-row>
@@ -84,7 +84,7 @@
             Help: how do I&nbsp;<b-link href="https://www.wikihow.com/Put-Game-Saves-on-Your-PSP">copy PS1 saves to and from my PSP</b-link>?
           </div>
           <div class="help">
-            Help: how do I copy save files to and from a PS1 memory card?<br><b-link href="http://ps2ulaunchelf.pbworks.com/w/page/19520134/FrontPage">PS2 + USB stick</b-link> or <b-link href="https://github.com/ShendoXT/memcardrex/releases">PS3 USB memory card adaptor</b-link> or <b-link href="https://github.com/ShendoXT/memcardrex/releases">DexDrive</b-link> or <b-link href="https://8bitmods.com/memcard-pro-for-playstation-1-smoke-black/">MemCard Pro</b-link>
+            Help: how do I copy individual save files to and from a PS1 memory card?<br><b-link href="http://ps2ulaunchelf.pbworks.com/w/page/19520134/FrontPage">PS2 + USB stick</b-link> or <b-link href="https://github.com/ShendoXT/memcardrex/releases">PS3 USB memory card adaptor</b-link> or <b-link href="https://github.com/ShendoXT/memcardrex/releases">DexDrive</b-link> or <b-link href="https://8bitmods.com/memcard-pro-for-playstation-1-smoke-black/">MemCard Pro</b-link>
           </div>
           <div class="help">
             Help: how do I <b-link href="https://www.google.com/search?q=ps2+mcboot+memory+card">run homebrew software on my PS2</b-link>?
@@ -105,6 +105,16 @@
 .help {
   margin-top: 1em;
 }
+
+/* We have so much text in our jumbotron that at the md size it wants to be vertically larger than the other one. So let's constrain it and move the text upwards insie it */
+.fix-jumbotron {
+  max-height: 11.5em;
+}
+
+.fix-jumbotron > div {
+  margin-top: -1em;
+}
+
 </style>
 
 <script>

--- a/frontend/src/components/ConvertPs1Psp.vue
+++ b/frontend/src/components/ConvertPs1Psp.vue
@@ -57,6 +57,11 @@
               :leaveRoomForHelpIcon="false"
               :allowMultipleFiles="true"
             />
+            <file-list
+              :display="this.pspSaveData !== null"
+              :files="this.pspSaveData ? this.pspSaveData.getSaveFiles() : []"
+              :enabled="false"
+            />
           </div>
         </b-col>
       </b-row>

--- a/frontend/src/components/FileList.vue
+++ b/frontend/src/components/FileList.vue
@@ -46,6 +46,10 @@ export default {
       type: Number,
       default: null,
     },
+    enabled: {
+      type: Boolean,
+      default: true,
+    },
   },
   model: {
     prop: 'value',
@@ -53,7 +57,8 @@ export default {
   },
   computed: {
     options() {
-      return this.files.map((f, i) => ({ value: i, text: f.description }));
+      const optionsEnabled = this.enabled;
+      return this.files.map((f, i) => ({ value: i, text: f.description, disabled: !optionsEnabled }));
     },
     valueLocal: {
       get() { return this.value; },

--- a/frontend/src/views/DownloadSaves.vue
+++ b/frontend/src/views/DownloadSaves.vue
@@ -51,7 +51,7 @@
         <b-link href="https://www.zophar.net/savestates.html">Zophar's{{'\xa0'}}Domain</b-link>
       </b-col>
       <b-col cols=12 md=5 lg=5 xl=4>
-        Mostly save states, but same save files as well.
+        Mostly save states, but some save files as well.
       </b-col>
     </b-row>
     <div class="blank-line"/>


### PR DESCRIPTION
- Add file list when constructing a save file, to make it clearer what you're including
- Rename 'raw/emulator' -> 'individual save' to be clearer that the individual files won't work straight in an emulator (they are raw, however!)
- Add a horizontal rule to help separate the ever-growing top nav from the rest of the page
- Fix a typo on the download saves page