### PR TITLE
Convert full-width characters from PS1 file descriptions to normal half-width characters

### DIFF
--- a/frontend/src/save-formats/PS1/Memcard.js
+++ b/frontend/src/save-formats/PS1/Memcard.js
@@ -45,8 +45,8 @@ const SAVE_BLOCK_DESCRIPTION_ENCODING = 'shift-jis';
 
 function convertTextToHalfWidth(s) {
   // The description stored in the save data is in full-width characters but we'd rather display normal half-width ones
-  // https://stackoverflow.com/a/20488304
-  return s.replace(/[\uff01-\uff5e]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0xfee0));
+  // https://stackoverflow.com/a/58515363
+  return s.replace(/[\uff01-\uff5e]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0xfee0)).replace(/\u3000/g, '\u0020');
 }
 
 function getDirectoryFrame(headerArrayBuffer, blockNum) {

--- a/frontend/src/save-formats/PS1/Memcard.js
+++ b/frontend/src/save-formats/PS1/Memcard.js
@@ -43,6 +43,12 @@ const SAVE_BLOCK_DESCRIPTION_OFFSET = 0x04;
 const SAVE_BLOCK_DESCRIPTION_LENGTH = 64;
 const SAVE_BLOCK_DESCRIPTION_ENCODING = 'shift-jis';
 
+function convertTextToHalfWidth(s) {
+  // The description stored in the save data is in full-width characters but we'd rather display normal half-width ones
+  // https://stackoverflow.com/a/20488304
+  return s.replace(/[\uff01-\uff5e]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0xfee0));
+}
+
 function getDirectoryFrame(headerArrayBuffer, blockNum) {
   const offset = FRAME_SIZE + (blockNum * FRAME_SIZE); // The first frame contains HEADER_MAGIC, so block 0 is at frame 1
   return headerArrayBuffer.slice(offset, offset + FRAME_SIZE);
@@ -316,7 +322,13 @@ export default class Ps1MemcardSaveData {
 
         Util.checkMagic(dataBlocks[0], 0, SAVE_BLOCK_MAGIC, MAGIC_ENCODING);
 
-        const description = Util.trimNull(fileDescriptionTextDecoder.decode(dataBlocks[0].slice(SAVE_BLOCK_DESCRIPTION_OFFSET, SAVE_BLOCK_DESCRIPTION_OFFSET + SAVE_BLOCK_DESCRIPTION_LENGTH)));
+        const description = convertTextToHalfWidth(
+          Util.trimNull(
+            fileDescriptionTextDecoder.decode(
+              dataBlocks[0].slice(SAVE_BLOCK_DESCRIPTION_OFFSET, SAVE_BLOCK_DESCRIPTION_OFFSET + SAVE_BLOCK_DESCRIPTION_LENGTH),
+            ),
+          ),
+        );
 
         // See if there are other blocks that comprise this save
 

--- a/frontend/tests/unit/save-formats/PS1/DexDrive.spec.js
+++ b/frontend/tests/unit/save-formats/PS1/DexDrive.spec.js
@@ -44,7 +44,7 @@ describe('PS1 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-00067DRAX01');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal('');
-    expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('ＣＡＳＴＬＥＶＡＮＩＡ－２　ＰＨＯＥＮＩＸ　２０８％');
+    expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('CASTLEVANIA-2 PHOENIX 208%');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawArrayBuffer)).to.equal(true);
   });
 
@@ -59,13 +59,13 @@ describe('PS1 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-00067DRAX00');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal('');
-    expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('ＣＡＳＴＬＥＶＡＮＩＡ－１　ＡＬＵＣＡＲＤ　２００％');
+    expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('CASTLEVANIA-1 ALUCARD 200%');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawArrayBuffers[0])).to.equal(true);
 
     expect(dexDriveSaveData.getSaveFiles()[1].startingBlock).to.equal(1);
     expect(dexDriveSaveData.getSaveFiles()[1].filename).to.equal('BASLUS-00067DRAX01');
     expect(dexDriveSaveData.getSaveFiles()[1].comment).to.equal('');
-    expect(dexDriveSaveData.getSaveFiles()[1].description).to.equal('ＣＡＳＴＬＥＶＡＮＩＡ－２　ＲＩＣＨＴＥＲ　１９５％');
+    expect(dexDriveSaveData.getSaveFiles()[1].description).to.equal('CASTLEVANIA-2 RICHTER 195%');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[1].rawData, rawArrayBuffers[1])).to.equal(true);
   });
 
@@ -80,7 +80,7 @@ describe('PS1 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASCUS-94194GT');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal('');
-    expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('ＧＴ　ｇａｍｅ　ｄａｔａ');
+    expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('GT game data');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawArrayBuffer)).to.equal(true);
   });
 
@@ -95,13 +95,13 @@ describe('PS1 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(6);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASCUS-94194GT');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal('');
-    expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('ＧＴ　ｇａｍｅ　ｄａｔａ');
+    expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('GT game data');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawArrayBuffers[0])).to.equal(true);
 
     expect(dexDriveSaveData.getSaveFiles()[1].startingBlock).to.equal(12);
     expect(dexDriveSaveData.getSaveFiles()[1].filename).to.equal('BASCUS-94194RT');
     expect(dexDriveSaveData.getSaveFiles()[1].comment).to.equal('');
-    expect(dexDriveSaveData.getSaveFiles()[1].description).to.equal('ＧＴ　ｒｅｐｌａｙ　ｄａｔａ');
+    expect(dexDriveSaveData.getSaveFiles()[1].description).to.equal('GT replay data');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[1].rawData, rawArrayBuffers[1])).to.equal(true);
   });
 
@@ -118,13 +118,13 @@ describe('PS1 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASCUS-94194GT');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal(COMMENTS[0]);
-    expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('ＧＴ　ｇａｍｅ　ｄａｔａ');
+    expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('GT game data');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, saveFilesArrayBuffers[0])).to.equal(true);
 
     expect(dexDriveSaveData.getSaveFiles()[1].startingBlock).to.equal(5);
     expect(dexDriveSaveData.getSaveFiles()[1].filename).to.equal('BASCUS-94194RT');
     expect(dexDriveSaveData.getSaveFiles()[1].comment).to.equal(COMMENTS[1]);
-    expect(dexDriveSaveData.getSaveFiles()[1].description).to.equal('ＧＴ　ｒｅｐｌａｙ　ｄａｔａ');
+    expect(dexDriveSaveData.getSaveFiles()[1].description).to.equal('GT replay data');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[1].rawData, saveFilesArrayBuffers[1])).to.equal(true);
 
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getArrayBuffer(), dexDriveArrayBuffer)).to.equal(true);

--- a/frontend/tests/unit/save-formats/PS1/Memcard.spec.js
+++ b/frontend/tests/unit/save-formats/PS1/Memcard.spec.js
@@ -25,12 +25,12 @@ describe('PS1 memcard save format', () => {
 
     expect(ps1MemcardSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(ps1MemcardSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-00067DRAX00');
-    expect(ps1MemcardSaveData.getSaveFiles()[0].description).to.equal('ＣＡＳＴＬＥＶＡＮＩＡ－１　ＡＬＵＣＡＲＤ　２００％');
+    expect(ps1MemcardSaveData.getSaveFiles()[0].description).to.equal('CASTLEVANIA-1 ALUCARD 200%');
     expect(ArrayBufferUtil.arrayBuffersEqual(ps1MemcardSaveData.getSaveFiles()[0].rawData, saveFilesArrayBuffers[0])).to.equal(true);
 
     expect(ps1MemcardSaveData.getSaveFiles()[1].startingBlock).to.equal(1);
     expect(ps1MemcardSaveData.getSaveFiles()[1].filename).to.equal('BASLUS-00067DRAX01');
-    expect(ps1MemcardSaveData.getSaveFiles()[1].description).to.equal('ＣＡＳＴＬＥＶＡＮＩＡ－２　ＲＩＣＨＴＥＲ　１９５％');
+    expect(ps1MemcardSaveData.getSaveFiles()[1].description).to.equal('CASTLEVANIA-2 RICHTER 195%');
     expect(ArrayBufferUtil.arrayBuffersEqual(ps1MemcardSaveData.getSaveFiles()[1].rawData, saveFilesArrayBuffers[1])).to.equal(true);
   });
 
@@ -45,12 +45,12 @@ describe('PS1 memcard save format', () => {
 
     expect(ps1MemcardSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(ps1MemcardSaveData.getSaveFiles()[0].filename).to.equal('BASCUS-94194GT');
-    expect(ps1MemcardSaveData.getSaveFiles()[0].description).to.equal('ＧＴ　ｇａｍｅ　ｄａｔａ');
+    expect(ps1MemcardSaveData.getSaveFiles()[0].description).to.equal('GT game data');
     expect(ArrayBufferUtil.arrayBuffersEqual(ps1MemcardSaveData.getSaveFiles()[0].rawData, saveFilesArrayBuffers[0])).to.equal(true);
 
     expect(ps1MemcardSaveData.getSaveFiles()[1].startingBlock).to.equal(5);
     expect(ps1MemcardSaveData.getSaveFiles()[1].filename).to.equal('BASCUS-94194RT');
-    expect(ps1MemcardSaveData.getSaveFiles()[1].description).to.equal('ＧＴ　ｒｅｐｌａｙ　ｄａｔａ');
+    expect(ps1MemcardSaveData.getSaveFiles()[1].description).to.equal('GT replay data');
     expect(ArrayBufferUtil.arrayBuffersEqual(ps1MemcardSaveData.getSaveFiles()[1].rawData, saveFilesArrayBuffers[1])).to.equal(true);
   });
 
@@ -72,7 +72,7 @@ describe('PS1 memcard save format', () => {
 
     expect(ps1MemcardSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(ps1MemcardSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-00067DRAX00');
-    expect(ps1MemcardSaveData.getSaveFiles()[0].description).to.equal('ＣＡＳＴＬＥＶＡＮＩＡ－１　ＥＵＡＮ　２％');
+    expect(ps1MemcardSaveData.getSaveFiles()[0].description).to.equal('CASTLEVANIA-1 EUAN 2%');
     expect(ArrayBufferUtil.arrayBuffersEqual(ps1MemcardSaveData.getSaveFiles()[0].rawData, rawArrayBuffer)).to.equal(true);
   });
 });

--- a/frontend/tests/unit/save-formats/PS1/Psp.spec.js
+++ b/frontend/tests/unit/save-formats/PS1/Psp.spec.js
@@ -61,37 +61,37 @@ describe('PS1 - PSP save format', () => {
 
     expect(pspSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(pspSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-00958GS2-1');
-    expect(pspSaveData.getSaveFiles()[0].description).to.equal('ＳＵＩＫＯＤＥＮ２－（１）　ＬＶ５７　　３１：１１：３３');
+    expect(pspSaveData.getSaveFiles()[0].description).to.equal('SUIKODEN2-(1) LV57  31:11:33');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[0].rawData, rawArrayBuffers[0])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[1].startingBlock).to.equal(2);
     expect(pspSaveData.getSaveFiles()[1].filename).to.equal('BASLUS-00958GS2-2');
-    expect(pspSaveData.getSaveFiles()[1].description).to.equal('ＳＵＩＫＯＤＥＮ２－（２）　ＬＶ５７　　３１：１６：３５');
+    expect(pspSaveData.getSaveFiles()[1].description).to.equal('SUIKODEN2-(2) LV57  31:16:35');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[1].rawData, rawArrayBuffers[1])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[2].startingBlock).to.equal(4);
     expect(pspSaveData.getSaveFiles()[2].filename).to.equal('BASLUS-00958GS2-3');
-    expect(pspSaveData.getSaveFiles()[2].description).to.equal('ＳＵＩＫＯＤＥＮ２－（３）　ＬＶ５７　　３１：２５：１４');
+    expect(pspSaveData.getSaveFiles()[2].description).to.equal('SUIKODEN2-(3) LV57  31:25:14');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[2].rawData, rawArrayBuffers[2])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[3].startingBlock).to.equal(6);
     expect(pspSaveData.getSaveFiles()[3].filename).to.equal('BASLUS-00958GS2-4');
-    expect(pspSaveData.getSaveFiles()[3].description).to.equal('ＳＵＩＫＯＤＥＮ２－（４）　ＬＶ５４　　３０：３１：１２');
+    expect(pspSaveData.getSaveFiles()[3].description).to.equal('SUIKODEN2-(4) LV54  30:31:12');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[3].rawData, rawArrayBuffers[3])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[4].startingBlock).to.equal(8);
     expect(pspSaveData.getSaveFiles()[4].filename).to.equal('BASLUS-00958GS2-5');
-    expect(pspSaveData.getSaveFiles()[4].description).to.equal('ＳＵＩＫＯＤＥＮ２－（５）　ＬＶ５９　　３２：３０：２２');
+    expect(pspSaveData.getSaveFiles()[4].description).to.equal('SUIKODEN2-(5) LV59  32:30:22');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[4].rawData, rawArrayBuffers[4])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[5].startingBlock).to.equal(10);
     expect(pspSaveData.getSaveFiles()[5].filename).to.equal('BASLUS-00958GS2-6');
-    expect(pspSaveData.getSaveFiles()[5].description).to.equal('ＳＵＩＫＯＤＥＮ２－（６）　ＬＶ６０　　３２：３９：３９');
+    expect(pspSaveData.getSaveFiles()[5].description).to.equal('SUIKODEN2-(6) LV60  32:39:39');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[5].rawData, rawArrayBuffers[5])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[6].startingBlock).to.equal(12);
     expect(pspSaveData.getSaveFiles()[6].filename).to.equal('BASLUS-00958GS2-7');
-    expect(pspSaveData.getSaveFiles()[6].description).to.equal('ＳＵＩＫＯＤＥＮ２－（７）　ＬＶ６０　　３２：５４：４２');
+    expect(pspSaveData.getSaveFiles()[6].description).to.equal('SUIKODEN2-(7) LV60  32:54:42');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[6].rawData, rawArrayBuffers[6])).to.equal(true);
   });
 
@@ -107,12 +107,12 @@ describe('PS1 - PSP save format', () => {
 
     expect(pspSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(pspSaveData.getSaveFiles()[0].filename).to.equal('BASCUS-94194GT');
-    expect(pspSaveData.getSaveFiles()[0].description).to.equal('ＧＴ　ｇａｍｅ　ｄａｔａ');
+    expect(pspSaveData.getSaveFiles()[0].description).to.equal('GT game data');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[0].rawData, saveFilesArrayBuffers[0])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[1].startingBlock).to.equal(5);
     expect(pspSaveData.getSaveFiles()[1].filename).to.equal('BASCUS-94194RT');
-    expect(pspSaveData.getSaveFiles()[1].description).to.equal('ＧＴ　ｒｅｐｌａｙ　ｄａｔａ');
+    expect(pspSaveData.getSaveFiles()[1].description).to.equal('GT replay data');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[1].rawData, saveFilesArrayBuffers[1])).to.equal(true);
 
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getArrayBuffer(), pspArrayBuffer)).to.equal(true);


### PR DESCRIPTION
For some reason, the descriptions are encoded as full-width characters. So they take up a lot of room in the UI and are harder to read. This maps them back to normal half-width characters.