### PR TITLE
Send emails upon build success/failure

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -29,7 +29,7 @@ module "alarms" {
   region            = var.region
 
   topic_name        = var.application_name
-  alarms_email      = var.alarms_email
+  notifications_email = var.notifications_email
 
   bucket_name       = module.frontend.bucket_name
   bucket_metrics_filter_id = module.frontend.bucket_metrics_filter_id

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -17,7 +17,7 @@ variable "application_name" {
 variable "bucketname_user_string" {
 }
 
-variable "alarms_email" {
+variable "notifications_email" {
 }
 
 variable "application_domain" {

--- a/terraform/modules/alarms/outputs.tf
+++ b/terraform/modules/alarms/outputs.tf
@@ -1,0 +1,4 @@
+output "sns_topic_arn" {
+  value       = aws_sns_topic.alarms.arn
+  description = "ARN alarms SNS topic"
+}

--- a/terraform/modules/alarms/sns-topic.tf
+++ b/terraform/modules/alarms/sns-topic.tf
@@ -23,7 +23,7 @@ resource "aws_sns_topic" "alarms" {
 EOF
 
   provisioner "local-exec" {
-    command = "aws sns subscribe --topic-arn ${self.arn} --protocol email --notification-endpoint ${var.alarms_email} --region ${var.region}"
+    command = "aws sns subscribe --topic-arn ${self.arn} --protocol email --notification-endpoint ${var.notifications_email} --region ${var.region}"
   }
 }
 

--- a/terraform/modules/alarms/variables.tf
+++ b/terraform/modules/alarms/variables.tf
@@ -7,7 +7,7 @@ variable "region" {
 variable "topic_name" {
 }
 
-variable "alarms_email" {
+variable "notifications_email" {
 }
 
 variable "enable_alarms" {

--- a/terraform/modules/build-common-infrastructure/outputs.tf
+++ b/terraform/modules/build-common-infrastructure/outputs.tf
@@ -8,3 +8,7 @@ output "build_logs_bucket_id" {
   description = "ID of the bucket that will contain our build logs"
 }
 
+output "sns_topic_arn" {
+  value       = aws_sns_topic.builds.arn
+  description = "ARN for the SNS topic used to receive build events"
+}

--- a/terraform/modules/build-common-infrastructure/role.tf
+++ b/terraform/modules/build-common-infrastructure/role.tf
@@ -2,7 +2,7 @@
 # The policy is also detailed here: https://docs.aws.amazon.com/codebuild/latest/userguide/auth-and-access-control-iam-identity-based-access-control.html#customer-managed-policies-example-create-vpc-network-interface
 
 resource "aws_iam_role" "build_common_infrastructure" {
-  name = "codebuild-${var.environment}"
+  name = "${var.application_name}-codebuild-${var.environment}"
 
   assume_role_policy = <<EOF
 {
@@ -96,6 +96,29 @@ resource "aws_iam_role_policy" "build_common_infrastructure" {
         "ecr:InitiateLayerUpload",
         "ecr:PutImage",
         "ecr:UploadLayerPart"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    },
+    {
+      "Sid": "SNSAccessPolicy",
+      "Effect": "Allow",
+      "Action": [
+        "sns:CreateTopic",
+        "sns:GetTopicAttributes",
+        "sns:List*",
+        "sns:Publish",
+        "sns:SetTopicAttributes",
+        "sns:Subscribe"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
+        "events:*",
+        "iam:PassRole"
       ],
       "Resource": "*",
       "Effect": "Allow"

--- a/terraform/modules/build-common-infrastructure/sns-topic.tf
+++ b/terraform/modules/build-common-infrastructure/sns-topic.tf
@@ -1,6 +1,6 @@
 # Based on https://stephenmann.io/post/setting-up-monitoring-and-alerting-on-amazon-aws-with-terraform/
 
-resource "aws_sns_topic" "alarms" {
+resource "aws_sns_topic" "builds" {
   name            = "${var.topic_name}-${var.environment}"
   delivery_policy = <<EOF
 {

--- a/terraform/modules/build-common-infrastructure/sns-topic.tf
+++ b/terraform/modules/build-common-infrastructure/sns-topic.tf
@@ -26,3 +26,35 @@ EOF
     command = "aws sns subscribe --topic-arn ${self.arn} --protocol email --notification-endpoint ${var.notifications_email} --region ${var.region}"
   }
 }
+
+# EventBridge is supposed to automatically create a policy on the SNS topic: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-troubleshooting.html#eb-sns-permissions-persist
+# but it doesn't seem to in our case.
+# So adding it manually, based on: https://serverlessland.com/patterns/eventbridge-sns
+resource "aws_sns_topic_policy" "default" {
+  arn = aws_sns_topic.builds.arn
+
+  policy = data.aws_iam_policy_document.sns_builds_topic_policy.json
+}
+
+data "aws_iam_policy_document" "sns_builds_topic_policy" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    actions = [
+      "SNS:Publish"
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    resources = [
+      aws_sns_topic.builds.arn,
+    ]
+
+    sid = "__default_statement_ID"
+  }
+}

--- a/terraform/modules/build-common-infrastructure/variables.tf
+++ b/terraform/modules/build-common-infrastructure/variables.tf
@@ -34,3 +34,6 @@ variable "topic_name" {
 
 variable "notifications_email" {
 }
+
+variable "application_name" {
+}

--- a/terraform/modules/build-common-infrastructure/variables.tf
+++ b/terraform/modules/build-common-infrastructure/variables.tf
@@ -28,3 +28,9 @@ variable "s3_deployment_bucket_arn" {
 
 variable "cloudfront_distribution_arn" {
 }
+
+variable "topic_name" {
+}
+
+variable "notifications_email" {
+}

--- a/terraform/modules/build-pipeline-frontend/code-build.tf
+++ b/terraform/modules/build-pipeline-frontend/code-build.tf
@@ -1,5 +1,5 @@
 resource "aws_codebuild_project" "frontend" {
-  name          = "frontend-${var.environment}"
+  name          = "${var.application_name}-frontend-${var.environment}"
   description   = "Builds the ${var.environment} frontend"
   build_timeout = "5"
   service_role  = var.build_service_role_arn

--- a/terraform/modules/build-pipeline-frontend/eventbridge.tf
+++ b/terraform/modules/build-pipeline-frontend/eventbridge.tf
@@ -1,0 +1,62 @@
+# Based on https://docs.aws.amazon.com/codebuild/latest/userguide/sample-build-notifications.html
+
+resource "aws_cloudwatch_event_rule" "builds" {
+  name        = "${var.application_name}-frontend-${var.environment}-codebuild"
+  description = "Capture each codebuild success or failure event"
+
+  event_pattern = <<EOF
+{
+  "source": [ 
+    "aws.codebuild"
+  ], 
+  "detail-type": [
+    "CodeBuild Build State Change"
+  ],
+  "detail": {
+    "build-status": [
+      "SUCCEEDED", 
+      "FAILED",
+      "STOPPED" 
+    ],
+    "project-name": [
+      "${aws_codebuild_project.frontend.name}"
+    ]
+  }  
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "sns" {
+  rule      = aws_cloudwatch_event_rule.builds.name
+  target_id = "SendToSNS"
+  arn       = var.build_sns_topic_arn
+
+  input_transformer {
+    input_paths = {
+      build-id = "$.detail.build-id",
+      project-name = "$.detail.project-name",
+      build-status = "$.detail.build-status",
+    }
+    input_template = "\"<project-name> build <build-status> Build ID: <build-id>\"" # I can't get newlines to work here. \n results in terraform barfing, and \\n as suggested in the docs just inserts the characters "\n" into the email: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#input_template
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "codebuild_eventbridge_failedinvocations" {
+  alarm_name                = "${var.application_name} CodeBuild EventBridge FailedInvocations - ${var.environment}"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "FailedInvocations"
+  namespace                 = "AWS/Events"
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  treat_missing_data        = "notBreaching"
+  alarm_description         = "Alerts if there is a failure to publish a codebuild event to SNS"
+  alarm_actions             = [var.alarms_sns_topic_arn]
+  insufficient_data_actions = [var.alarms_sns_topic_arn]
+  ok_actions                = [var.alarms_sns_topic_arn]
+
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.builds.name
+  }
+}

--- a/terraform/modules/build-pipeline-frontend/variables.tf
+++ b/terraform/modules/build-pipeline-frontend/variables.tf
@@ -7,6 +7,9 @@ variable "environment_long_name" {
 variable "region" {
 }
 
+variable "application_name" {
+}
+
 variable "project_github_location" {
 }
 
@@ -23,4 +26,10 @@ variable "file_path" {
 }
 
 variable "build_service_role_arn" {
+}
+
+variable "build_sns_topic_arn" {
+}
+
+variable "alarms_sns_topic_arn" {
 }

--- a/terraform/modules/frontend/build.tf
+++ b/terraform/modules/frontend/build.tf
@@ -6,10 +6,13 @@ module "build" {
   environment              = var.environment
   environment_long_name    = var.environment_long_name
   region                   = var.region
+  application_name         = var.application_name
   project_github_location  = var.project_github_location
   build_logs_bucket_id     = var.build_logs_bucket_id
   s3_deployment_bucket_arn = aws_s3_bucket.frontend.arn
   buildspec_location       = var.buildspec_location
   file_path                = var.file_path
   build_service_role_arn   = var.build_service_role_arn
+  build_sns_topic_arn      = var.build_sns_topic_arn
+  alarms_sns_topic_arn     = var.alarms_sns_topic_arn
 }

--- a/terraform/modules/frontend/variables.tf
+++ b/terraform/modules/frontend/variables.tf
@@ -59,3 +59,9 @@ variable "file_path" {
 variable "build_service_role_arn" {
   default = ""
 }
+
+variable "build_sns_topic_arn" {
+}
+
+variable "alarms_sns_topic_arn" {
+}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -52,7 +52,7 @@ module "alarms" {
   region            = var.region
 
   topic_name        = var.application_name
-  alarms_email      = var.alarms_email
+  notifications_email = var.notifications_email
 
   bucket_name       = module.frontend.bucket_name
   bucket_metrics_filter_id = module.frontend.bucket_metrics_filter_id

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -25,11 +25,14 @@ module "frontend" {
   buildspec_location      = "frontend/buildspec.yml"
   file_path               = "frontend/*"
   build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
+  build_sns_topic_arn     = module.build-common-infrastructure.sns_topic_arn
+  alarms_sns_topic_arn    = module.alarms.sns_topic_arn
 }
 
 module "build-common-infrastructure" {
   source = "../modules/build-common-infrastructure"
 
+  application_name      = var.application_name
   environment           = var.environment
   environment_long_name = var.environment_long_name
   region                = var.region

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -43,6 +43,9 @@ module "build-common-infrastructure" {
   bucketname_user_string          = var.bucketname_user_string
   retain_build_logs_after_destroy = true # For prod we don't want to lose logs, even after a terraform destroy
   days_to_keep_build_logs         = 90
+
+  topic_name          = "${var.application_name}-builds"
+  notifications_email = var.notifications_email
 }
 
 module "alarms" {
@@ -51,7 +54,7 @@ module "alarms" {
   environment       = var.environment
   region            = var.region
 
-  topic_name        = var.application_name
+  topic_name          = "${var.application_name}-alarms"
   notifications_email = var.notifications_email
 
   bucket_name       = module.frontend.bucket_name

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -17,7 +17,7 @@ variable "application_name" {
 variable "bucketname_user_string" {
 }
 
-variable "alarms_email" {
+variable "notifications_email" {
 }
 
 variable "application_domain" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,7 +1,7 @@
 # This is added to the various bucket names so that they don't conflict with other instances of this project
 # e.g. if it's set to "-dave-" then the bucket "sample-project-dev" will become "sample-project-dave-dev"
 bucketname_user_string = ""
-alarms_email = ""
+notifications_email = ""
 application_domain = ""
 route_53_zone_id = "" # Zone created by Route 53 for our application domain
 project_github_location = "https://github.com/euan-forrester/save-file-converter"


### PR DESCRIPTION
- Created SNS topic for build emails
- Hooked up CodeBuild to SNS topic via EventBridge
- Added alarm for when the integration fails

The emails aren't formatted very nicely. I guess with a Lambda function you can make them prettier, and include the actual build errors. But they work for now.

Fixes https://github.com/euan-forrester/save-file-converter/issues/65