### PR TITLE
Mister genesis cleanup

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta name="robots" content="max-image-preview:none">
-    <meta name="description" content="Converts save files for retro consoles between different formats including Wii Virtual Console, PS1, N64, DexDrive, GameShark, Retron 5, PSP, and Action Replay. Decrypts PSP saves. Provides help for troubleshooting converted files and erasing cartridges." />
+    <meta name="description" content="Converts save files for retro consoles between different formats including Wii Virtual Console, PS1, N64, DexDrive, GameShark, Retron 5, MiSTer, PSP, and Action Replay. Decrypts PSP saves. Provides help for troubleshooting converted files, erasing cartridge saves, and copying saves to and from original hardware." />
     <link rel="apple-touch-icon" sizes="180x180" href="<%= BASE_URL %>apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="<%= BASE_URL %>favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="<%= BASE_URL %>favicon-16x16.png">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,6 +9,11 @@
       </b-row>
       <b-row>
         <b-col class="nav-row">
+          <router-link to="/mister">MiSTer{{'\xa0'}}(Beta)</router-link>
+        </b-col>
+      </b-row>
+      <b-row>
+        <b-col class="nav-row">
           <router-link to="/wii">Wii{{'\xa0'}}Virtual{{'\xa0'}}Console (NES, SNES, N64, TG-16, SMS, Genesis, Neo{{'\xa0'}}Geo, C64)</router-link>
         </b-col>
       </b-row>
@@ -81,7 +86,7 @@
   color: #2c3e50;
 }
 
-#nav a.router-link-active {
+#nav a.router-link-exact-active {
   color: #42b983;
 }
 

--- a/frontend/src/components/FileInfo.vue
+++ b/frontend/src/components/FileInfo.vue
@@ -22,7 +22,7 @@
 </style>
 
 <script>
-import Troubleshooting from '../util/Troubleshooting';
+import PaddingUtil from '../util/Padding';
 
 export default {
   name: 'FileInfo',
@@ -60,7 +60,7 @@ export default {
   },
   methods: {
     getFileSize(fileData) { return fileData ? fileData.byteLength : 0; },
-    getInitialPadding(fileData) { return fileData ? Troubleshooting.getPadValueAndCount(fileData).count : 0; },
+    getInitialPadding(fileData) { return fileData ? PaddingUtil.getPadValueAndCount(fileData).count : 0; },
     getRemainingSaveSize(fileData) { return this.getFileSize(fileData) - this.getInitialPadding(fileData); },
     getVariantForNumericalValue(getter) {
       if (!this.fileData || !this.otherFileData) {

--- a/frontend/src/components/TroubleshootingUtils.vue
+++ b/frontend/src/components/TroubleshootingUtils.vue
@@ -130,7 +130,7 @@ import path from 'path';
 import { saveAs } from 'file-saver';
 import InputFile from './InputFile.vue';
 import FileInfo from './FileInfo.vue';
-import Troubleshooting from '../util/Troubleshooting';
+import PaddingUtil from '../util/Padding';
 
 export default {
   name: 'TroubleshootingUtils',
@@ -156,7 +156,7 @@ export default {
       return this.testSaveData
       && this.brokenSaveData
       && (this.testSaveDataFilename === this.brokenSaveDataFilename)
-      && Troubleshooting.fileSizeAndPaddingIsSame(this.testSaveData, this.brokenSaveData);
+      && PaddingUtil.fileSizeAndPaddingIsSame(this.testSaveData, this.brokenSaveData);
     },
   },
   components: {
@@ -173,7 +173,7 @@ export default {
       this.brokenSaveDataFilename = path.basename(event.filename);
     },
     fixFile() {
-      const outputArrayBuffer = Troubleshooting.attemptFix(this.testSaveData, this.brokenSaveData);
+      const outputArrayBuffer = PaddingUtil.attemptFix(this.testSaveData, this.brokenSaveData);
 
       const outputBlob = new Blob([outputArrayBuffer], { type: 'application/octet-stream' });
 

--- a/frontend/src/save-formats/Mister/Genesis.js
+++ b/frontend/src/save-formats/Mister/Genesis.js
@@ -4,7 +4,7 @@ The MiSTer saves Genesis data as bytes (similar to the internal Wii format) rath
 Based on https://github.com/superg/srmtools
 */
 
-import Troubleshooting from '../../util/Troubleshooting';
+import PaddingUtil from '../../util/Padding';
 
 const LITTLE_ENDIAN = false;
 
@@ -21,7 +21,7 @@ function padArrayBuffer(inputArrayBuffer) {
     count: Math.max(MISTER_FILE_SIZE - inputArrayBuffer.byteLength, 0),
   };
 
-  return Troubleshooting.addPaddingToEnd(inputArrayBuffer, padding);
+  return PaddingUtil.addPaddingToEnd(inputArrayBuffer, padding);
 }
 
 export default class MisterGenesisSaveData {

--- a/frontend/src/util/Padding.js
+++ b/frontend/src/util/Padding.js
@@ -2,7 +2,7 @@
 
 import MathUtil from './Math';
 
-function fixCountSoSaveIsPowerOf2(arrayBuffer, count) {
+function fixCountSoSaveSizeIsPowerOf2(arrayBuffer, count) {
   // Most raw save files (for cartridges anyway) have sizes that are a power of 2,
   // because it's stored on a chip of one type or another and that's how they're manufactured.
   //
@@ -74,7 +74,7 @@ export default class PaddingUtil {
       count = padFFCount;
     }
 
-    count = fixCountSoSaveIsPowerOf2(arrayBuffer, count);
+    count = fixCountSoSaveSizeIsPowerOf2(arrayBuffer, count);
 
     return {
       value,
@@ -94,7 +94,7 @@ export default class PaddingUtil {
       count = padFFCount;
     }
 
-    count = fixCountSoSaveIsPowerOf2(arrayBuffer, count);
+    count = fixCountSoSaveSizeIsPowerOf2(arrayBuffer, count);
 
     return {
       value,

--- a/frontend/src/util/Padding.js
+++ b/frontend/src/util/Padding.js
@@ -50,8 +50,8 @@ export default class PaddingUtil {
   }
 
   static getPadValueAndCount(arrayBuffer) {
-    const pad00Count = PaddingUtil.countPadding(arrayBuffer, 0x00);
-    const padFFCount = PaddingUtil.countPadding(arrayBuffer, 0xFF);
+    const pad00Count = PaddingUtil.countPaddingFromStart(arrayBuffer, 0x00);
+    const padFFCount = PaddingUtil.countPaddingFromStart(arrayBuffer, 0xFF);
 
     let value = 0x00;
     let count = pad00Count;
@@ -114,11 +114,33 @@ export default class PaddingUtil {
     return newArrayBuffer;
   }
 
-  static countPadding(arrayBuffer, padValue) {
+  static countPaddingFromStart(arrayBuffer, padValue) {
     const uint8Array = new Uint8Array(arrayBuffer);
     let count = 0;
 
     for (let i = 0; i < uint8Array.length; i += 1) {
+      if (uint8Array[i] !== padValue) {
+        break;
+      }
+      count += 1;
+    }
+
+    // If everything looks like padding, then nothing is. This can happen, for example,
+    // when a user quickly creates a test save file without actually saving in-game. Not
+    // much we can do in that case other than to assume the whole thing is the correct size.
+    // Should flag the user that they need to provide a better file.
+    if (count === arrayBuffer.byteLength) {
+      count = 0;
+    }
+
+    return count;
+  }
+
+  static countPaddingFromEnd(arrayBuffer, padValue) {
+    const uint8Array = new Uint8Array(arrayBuffer);
+    let count = 0;
+
+    for (let i = uint8Array.length - 1; i >= 0; i -= 1) {
       if (uint8Array[i] !== padValue) {
         break;
       }

--- a/frontend/src/util/Padding.js
+++ b/frontend/src/util/Padding.js
@@ -2,15 +2,15 @@
 
 import MathUtil from './Math';
 
-export default class Troubleshooting {
+export default class PaddingUtil {
   static attemptFix(testSaveArrayBuffer, brokenSaveArrayBuffer) {
     // First, temporarily remove any padding from the start of the 2 saves
 
-    const testSavePadding = Troubleshooting.getPadValueAndCount(testSaveArrayBuffer);
-    const brokenSavePadding = Troubleshooting.getPadValueAndCount(brokenSaveArrayBuffer);
+    const testSavePadding = PaddingUtil.getPadValueAndCount(testSaveArrayBuffer);
+    const brokenSavePadding = PaddingUtil.getPadValueAndCount(brokenSaveArrayBuffer);
 
-    const testSaveNoPaddingAtStart = Troubleshooting.removePaddingFromStart(testSaveArrayBuffer, testSavePadding.count);
-    const brokenSaveNoPaddingAtStart = Troubleshooting.removePaddingFromStart(brokenSaveArrayBuffer, brokenSavePadding.count);
+    const testSaveNoPaddingAtStart = PaddingUtil.removePaddingFromStart(testSaveArrayBuffer, testSavePadding.count);
+    const brokenSaveNoPaddingAtStart = PaddingUtil.removePaddingFromStart(brokenSaveArrayBuffer, brokenSavePadding.count);
 
     // Now make the remainder of the broken save be the same length as the remainder of the good save
 
@@ -22,14 +22,14 @@ export default class Troubleshooting {
         count: testSaveNoPaddingAtStart.byteLength - brokenSaveNoPaddingAtStart.byteLength,
       };
 
-      brokenSaveNoPaddingAtStartCorrectLength = Troubleshooting.addPaddingToEnd(brokenSaveNoPaddingAtStart, endPadding);
+      brokenSaveNoPaddingAtStartCorrectLength = PaddingUtil.addPaddingToEnd(brokenSaveNoPaddingAtStart, endPadding);
     } else if (brokenSaveNoPaddingAtStart.byteLength > testSaveNoPaddingAtStart.byteLength) {
-      brokenSaveNoPaddingAtStartCorrectLength = Troubleshooting.removePaddingFromEnd(brokenSaveNoPaddingAtStart, brokenSaveNoPaddingAtStart.byteLength - testSaveNoPaddingAtStart.byteLength);
+      brokenSaveNoPaddingAtStartCorrectLength = PaddingUtil.removePaddingFromEnd(brokenSaveNoPaddingAtStart, brokenSaveNoPaddingAtStart.byteLength - testSaveNoPaddingAtStart.byteLength);
     }
 
     // Now add back any padding to the start that was present in the good save
 
-    const brokenSaveFixed = Troubleshooting.addPaddingToStart(brokenSaveNoPaddingAtStartCorrectLength, testSavePadding);
+    const brokenSaveFixed = PaddingUtil.addPaddingToStart(brokenSaveNoPaddingAtStartCorrectLength, testSavePadding);
 
     return brokenSaveFixed;
   }
@@ -39,8 +39,8 @@ export default class Troubleshooting {
       return false;
     }
 
-    const padding1 = Troubleshooting.getPadValueAndCount(arrayBuffer1);
-    const padding2 = Troubleshooting.getPadValueAndCount(arrayBuffer2);
+    const padding1 = PaddingUtil.getPadValueAndCount(arrayBuffer1);
+    const padding2 = PaddingUtil.getPadValueAndCount(arrayBuffer2);
 
     if ((padding1.count !== padding2.count) || (padding1.value !== padding2.value)) {
       return false;
@@ -50,8 +50,8 @@ export default class Troubleshooting {
   }
 
   static getPadValueAndCount(arrayBuffer) {
-    const pad00Count = Troubleshooting.countPadding(arrayBuffer, 0x00);
-    const padFFCount = Troubleshooting.countPadding(arrayBuffer, 0xFF);
+    const pad00Count = PaddingUtil.countPadding(arrayBuffer, 0x00);
+    const padFFCount = PaddingUtil.countPadding(arrayBuffer, 0xFF);
 
     let value = 0x00;
     let count = pad00Count;

--- a/frontend/src/util/Padding.js
+++ b/frontend/src/util/Padding.js
@@ -6,8 +6,8 @@ export default class PaddingUtil {
   static attemptFix(testSaveArrayBuffer, brokenSaveArrayBuffer) {
     // First, temporarily remove any padding from the start of the 2 saves
 
-    const testSavePadding = PaddingUtil.getPadValueAndCount(testSaveArrayBuffer);
-    const brokenSavePadding = PaddingUtil.getPadValueAndCount(brokenSaveArrayBuffer);
+    const testSavePadding = PaddingUtil.getPadFromStartValueAndCount(testSaveArrayBuffer);
+    const brokenSavePadding = PaddingUtil.getPadFromStartValueAndCount(brokenSaveArrayBuffer);
 
     const testSaveNoPaddingAtStart = PaddingUtil.removePaddingFromStart(testSaveArrayBuffer, testSavePadding.count);
     const brokenSaveNoPaddingAtStart = PaddingUtil.removePaddingFromStart(brokenSaveArrayBuffer, brokenSavePadding.count);
@@ -34,13 +34,13 @@ export default class PaddingUtil {
     return brokenSaveFixed;
   }
 
-  static fileSizeAndPaddingIsSame(arrayBuffer1, arrayBuffer2) {
+  static fileSizeAndPaddingFromStartIsSame(arrayBuffer1, arrayBuffer2) {
     if (arrayBuffer1.byteLength !== arrayBuffer2.byteLength) {
       return false;
     }
 
-    const padding1 = PaddingUtil.getPadValueAndCount(arrayBuffer1);
-    const padding2 = PaddingUtil.getPadValueAndCount(arrayBuffer2);
+    const padding1 = PaddingUtil.getPadFromStartValueAndCount(arrayBuffer1);
+    const padding2 = PaddingUtil.getPadFromStartValueAndCount(arrayBuffer2);
 
     if ((padding1.count !== padding2.count) || (padding1.value !== padding2.value)) {
       return false;
@@ -49,7 +49,7 @@ export default class PaddingUtil {
     return true;
   }
 
-  static getPadValueAndCount(arrayBuffer) {
+  static getPadFromStartValueAndCount(arrayBuffer) {
     const pad00Count = PaddingUtil.countPaddingFromStart(arrayBuffer, 0x00);
     const padFFCount = PaddingUtil.countPaddingFromStart(arrayBuffer, 0xFF);
 

--- a/frontend/tests/unit/save-formats/Mister/Genesis.spec.js
+++ b/frontend/tests/unit/save-formats/Mister/Genesis.spec.js
@@ -17,7 +17,6 @@ describe('MiSTer - Genesis save format', () => {
     expect(ArrayBufferUtil.arrayBuffersEqual(misterGenesisSaveData.getMisterArrayBuffer(), misterArrayBuffer)).to.equal(true);
   });
 
-/*
   it('should convert a MiSTer Genesis save to raw format', async () => {
     const rawArrayBuffer = await ArrayBufferUtil.readArrayBuffer(RAW_PHANTASY_STAR_2_FILENAME);
     const misterArrayBuffer = await ArrayBufferUtil.readArrayBuffer(MISTER_PHANTASY_STAR_2_FILENAME);
@@ -26,5 +25,4 @@ describe('MiSTer - Genesis save format', () => {
 
     expect(ArrayBufferUtil.arrayBuffersEqual(misterGenesisSaveData.getRawArrayBuffer(), rawArrayBuffer)).to.equal(true);
   });
-*/
 });

--- a/frontend/tests/unit/util/Padding.spec.js
+++ b/frontend/tests/unit/util/Padding.spec.js
@@ -11,7 +11,7 @@ const PADDING_VALUE_B = 0xFF;
 const EXTRA_PADDING_COUNT = 16;
 
 describe('PaddingUtil', () => {
-  it('should get the pad value and count', () => {
+  it('should get the pad value and count from the start of the array', () => {
     const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => {
@@ -28,7 +28,7 @@ describe('PaddingUtil', () => {
     expect(padding.count).to.equal(EXTRA_PADDING_COUNT);
   });
 
-  it('should get the other pad value and count', () => {
+  it('should get the other pad value and count from the start of the array', () => {
     const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => {
@@ -45,7 +45,7 @@ describe('PaddingUtil', () => {
     expect(padding.count).to.equal(EXTRA_PADDING_COUNT);
   });
 
-  it('should maintain data size being a power of 2 when finding padding', () => {
+  it('should maintain data size being a power of 2 when finding padding from the start of the array', () => {
     expect(MathUtil.getNextLargestPowerOf2(ARRAY_BUFFER_SIZE)).to.equal(ARRAY_BUFFER_SIZE);
 
     const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
@@ -64,7 +64,7 @@ describe('PaddingUtil', () => {
     expect(padding.count).to.equal(EXTRA_PADDING_COUNT); // The extra byte of padding isn't counted
   });
 
-  it('should get the pad count when there\'s no padding', () => {
+  it('should get the pad count from the start when there\'s no padding', () => {
     const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => {
@@ -76,7 +76,7 @@ describe('PaddingUtil', () => {
     expect(padding.count).to.equal(0);
   });
 
-  it('should get the pad count when it\'s al padding', () => {
+  it('should get the pad count from the start when it\'s al padding', () => {
     const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => {
@@ -84,6 +84,83 @@ describe('PaddingUtil', () => {
     });
 
     const padding = PaddingUtil.getPadFromStartValueAndCount(arrayBuffer);
+
+    expect(padding.count).to.equal(0);
+  });
+
+  it('should get the pad value and count from the end of the array', () => {
+    const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
+    const uint8Array = new Uint8Array(arrayBuffer);
+    uint8Array.forEach((e, i, a) => {
+      if (i >= ARRAY_BUFFER_SIZE) {
+        a[i] = PADDING_VALUE_A;
+      } else {
+        a[i] = DATA_VALUE;
+      }
+    });
+
+    const padding = PaddingUtil.getPadFromEndValueAndCount(arrayBuffer);
+
+    expect(padding.value).to.equal(PADDING_VALUE_A);
+    expect(padding.count).to.equal(EXTRA_PADDING_COUNT);
+  });
+
+  it('should get the other pad value and count from the end of the array', () => {
+    const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
+    const uint8Array = new Uint8Array(arrayBuffer);
+    uint8Array.forEach((e, i, a) => {
+      if (i >= ARRAY_BUFFER_SIZE) {
+        a[i] = PADDING_VALUE_B;
+      } else {
+        a[i] = DATA_VALUE;
+      }
+    });
+
+    const padding = PaddingUtil.getPadFromEndValueAndCount(arrayBuffer);
+
+    expect(padding.value).to.equal(PADDING_VALUE_B);
+    expect(padding.count).to.equal(EXTRA_PADDING_COUNT);
+  });
+
+  it('should maintain data size being a power of 2 when finding padding from the end of the array', () => {
+    expect(MathUtil.getNextLargestPowerOf2(ARRAY_BUFFER_SIZE)).to.equal(ARRAY_BUFFER_SIZE);
+
+    const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
+    const uint8Array = new Uint8Array(arrayBuffer);
+    uint8Array.forEach((e, i, a) => {
+      if (i >= (ARRAY_BUFFER_SIZE - 1)) { // One extra byte of padding
+        a[i] = PADDING_VALUE_B;
+      } else {
+        a[i] = DATA_VALUE;
+      }
+    });
+
+    const padding = PaddingUtil.getPadFromEndValueAndCount(arrayBuffer);
+
+    expect(padding.value).to.equal(PADDING_VALUE_B);
+    expect(padding.count).to.equal(EXTRA_PADDING_COUNT); // The extra byte of padding isn't counted
+  });
+
+  it('should get the pad count from the end when there\'s no padding', () => {
+    const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
+    const uint8Array = new Uint8Array(arrayBuffer);
+    uint8Array.forEach((e, i, a) => {
+      a[i] = DATA_VALUE;
+    });
+
+    const padding = PaddingUtil.getPadFromEndValueAndCount(arrayBuffer);
+
+    expect(padding.count).to.equal(0);
+  });
+
+  it('should get the pad count from the end when it\'s al padding', () => {
+    const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
+    const uint8Array = new Uint8Array(arrayBuffer);
+    uint8Array.forEach((e, i, a) => {
+      a[i] = PADDING_VALUE_B;
+    });
+
+    const padding = PaddingUtil.getPadFromEndValueAndCount(arrayBuffer);
 
     expect(padding.count).to.equal(0);
   });

--- a/frontend/tests/unit/util/Padding.spec.js
+++ b/frontend/tests/unit/util/Padding.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 
 import { expect } from 'chai';
-import Troubleshooting from '@/util/Troubleshooting';
+import PaddingUtil from '@/util/Padding';
 import MathUtil from '@/util/Math';
 
 const ARRAY_BUFFER_SIZE = 32;
@@ -10,7 +10,7 @@ const PADDING_VALUE_A = 0x00; // Two common values for padding used by various e
 const PADDING_VALUE_B = 0xFF;
 const EXTRA_PADDING_COUNT = 16;
 
-describe('Troubleshooting', () => {
+describe('PaddingUtil', () => {
   it('should get the pad value and count', () => {
     const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
     const uint8Array = new Uint8Array(arrayBuffer);
@@ -22,7 +22,7 @@ describe('Troubleshooting', () => {
       }
     });
 
-    const padding = Troubleshooting.getPadValueAndCount(arrayBuffer);
+    const padding = PaddingUtil.getPadValueAndCount(arrayBuffer);
 
     expect(padding.value).to.equal(PADDING_VALUE_A);
     expect(padding.count).to.equal(EXTRA_PADDING_COUNT);
@@ -39,7 +39,7 @@ describe('Troubleshooting', () => {
       }
     });
 
-    const padding = Troubleshooting.getPadValueAndCount(arrayBuffer);
+    const padding = PaddingUtil.getPadValueAndCount(arrayBuffer);
 
     expect(padding.value).to.equal(PADDING_VALUE_B);
     expect(padding.count).to.equal(EXTRA_PADDING_COUNT);
@@ -58,7 +58,7 @@ describe('Troubleshooting', () => {
       }
     });
 
-    const padding = Troubleshooting.getPadValueAndCount(arrayBuffer);
+    const padding = PaddingUtil.getPadValueAndCount(arrayBuffer);
 
     expect(padding.value).to.equal(PADDING_VALUE_B);
     expect(padding.count).to.equal(EXTRA_PADDING_COUNT); // The extra byte of padding isn't counted
@@ -71,7 +71,7 @@ describe('Troubleshooting', () => {
       a[i] = DATA_VALUE;
     });
 
-    const padding = Troubleshooting.getPadValueAndCount(arrayBuffer);
+    const padding = PaddingUtil.getPadValueAndCount(arrayBuffer);
 
     expect(padding.count).to.equal(0);
   });
@@ -83,7 +83,7 @@ describe('Troubleshooting', () => {
       a[i] = PADDING_VALUE_B;
     });
 
-    const padding = Troubleshooting.getPadValueAndCount(arrayBuffer);
+    const padding = PaddingUtil.getPadValueAndCount(arrayBuffer);
 
     expect(padding.count).to.equal(0);
   });
@@ -99,7 +99,7 @@ describe('Troubleshooting', () => {
       }
     });
 
-    const unpaddedArrayBuffer = Troubleshooting.removePaddingFromStart(arrayBuffer, EXTRA_PADDING_COUNT);
+    const unpaddedArrayBuffer = PaddingUtil.removePaddingFromStart(arrayBuffer, EXTRA_PADDING_COUNT);
 
     const unpaddedUint8Array = new Uint8Array(unpaddedArrayBuffer);
 
@@ -115,7 +115,7 @@ describe('Troubleshooting', () => {
       a[i] = DATA_VALUE;
     });
 
-    const unpaddedArrayBuffer = Troubleshooting.removePaddingFromStart(arrayBuffer, 0);
+    const unpaddedArrayBuffer = PaddingUtil.removePaddingFromStart(arrayBuffer, 0);
 
     const unpaddedUint8Array = new Uint8Array(unpaddedArrayBuffer);
 
@@ -135,7 +135,7 @@ describe('Troubleshooting', () => {
       }
     });
 
-    const unpaddedArrayBuffer = Troubleshooting.removePaddingFromEnd(arrayBuffer, EXTRA_PADDING_COUNT);
+    const unpaddedArrayBuffer = PaddingUtil.removePaddingFromEnd(arrayBuffer, EXTRA_PADDING_COUNT);
 
     const unpaddedUint8Array = new Uint8Array(unpaddedArrayBuffer);
 
@@ -151,7 +151,7 @@ describe('Troubleshooting', () => {
       a[i] = DATA_VALUE;
     });
 
-    const unpaddedArrayBuffer = Troubleshooting.removePaddingFromEnd(arrayBuffer, 0);
+    const unpaddedArrayBuffer = PaddingUtil.removePaddingFromEnd(arrayBuffer, 0);
 
     const unpaddedUint8Array = new Uint8Array(unpaddedArrayBuffer);
 
@@ -170,7 +170,7 @@ describe('Troubleshooting', () => {
       count: EXTRA_PADDING_COUNT,
     };
 
-    const paddedArrayBuffer = Troubleshooting.addPaddingToStart(arrayBuffer, padding);
+    const paddedArrayBuffer = PaddingUtil.addPaddingToStart(arrayBuffer, padding);
     expect(paddedArrayBuffer.byteLength).to.equal(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
 
     const paddedUint8Array = new Uint8Array(paddedArrayBuffer);
@@ -194,7 +194,7 @@ describe('Troubleshooting', () => {
       count: 0,
     };
 
-    const paddedArrayBuffer = Troubleshooting.addPaddingToStart(arrayBuffer, padding);
+    const paddedArrayBuffer = PaddingUtil.addPaddingToStart(arrayBuffer, padding);
     expect(paddedArrayBuffer.byteLength).to.equal(ARRAY_BUFFER_SIZE);
 
     const paddedUint8Array = new Uint8Array(paddedArrayBuffer);
@@ -212,7 +212,7 @@ describe('Troubleshooting', () => {
       count: EXTRA_PADDING_COUNT,
     };
 
-    const paddedArrayBuffer = Troubleshooting.addPaddingToEnd(arrayBuffer, padding);
+    const paddedArrayBuffer = PaddingUtil.addPaddingToEnd(arrayBuffer, padding);
     expect(paddedArrayBuffer.byteLength).to.equal(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
 
     const paddedUint8Array = new Uint8Array(paddedArrayBuffer);
@@ -236,7 +236,7 @@ describe('Troubleshooting', () => {
       count: 0,
     };
 
-    const paddedArrayBuffer = Troubleshooting.addPaddingToEnd(arrayBuffer, padding);
+    const paddedArrayBuffer = PaddingUtil.addPaddingToEnd(arrayBuffer, padding);
     expect(paddedArrayBuffer.byteLength).to.equal(ARRAY_BUFFER_SIZE);
 
     const paddedUint8Array = new Uint8Array(paddedArrayBuffer);
@@ -249,7 +249,7 @@ describe('Troubleshooting', () => {
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => { a[i] = DATA_VALUE; });
 
-    expect(Troubleshooting.countPadding(arrayBuffer, PADDING_VALUE_A)).to.equal(0);
+    expect(PaddingUtil.countPadding(arrayBuffer, PADDING_VALUE_A)).to.equal(0);
   });
 
   it('should count padding when it\'s all padding', () => {
@@ -257,7 +257,7 @@ describe('Troubleshooting', () => {
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => { a[i] = PADDING_VALUE_A; });
 
-    expect(Troubleshooting.countPadding(arrayBuffer, PADDING_VALUE_A)).to.equal(0);
+    expect(PaddingUtil.countPadding(arrayBuffer, PADDING_VALUE_A)).to.equal(0);
   });
 
   it('should count padding', () => {
@@ -265,7 +265,7 @@ describe('Troubleshooting', () => {
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => { a[i] = ((i < EXTRA_PADDING_COUNT) ? PADDING_VALUE_A : DATA_VALUE); });
 
-    expect(Troubleshooting.countPadding(arrayBuffer, PADDING_VALUE_A)).to.equal(EXTRA_PADDING_COUNT);
+    expect(PaddingUtil.countPadding(arrayBuffer, PADDING_VALUE_A)).to.equal(EXTRA_PADDING_COUNT);
   });
 
   it('should count different values of padding', () => {
@@ -273,6 +273,6 @@ describe('Troubleshooting', () => {
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => { a[i] = ((i < EXTRA_PADDING_COUNT) ? PADDING_VALUE_B : DATA_VALUE); });
 
-    expect(Troubleshooting.countPadding(arrayBuffer, PADDING_VALUE_B)).to.equal(EXTRA_PADDING_COUNT);
+    expect(PaddingUtil.countPadding(arrayBuffer, PADDING_VALUE_B)).to.equal(EXTRA_PADDING_COUNT);
   });
 });

--- a/frontend/tests/unit/util/Padding.spec.js
+++ b/frontend/tests/unit/util/Padding.spec.js
@@ -244,35 +244,67 @@ describe('PaddingUtil', () => {
     paddedUint8Array.forEach((e, i, a) => { expect(a[i]).to.equal(DATA_VALUE, `index ${i}`); });
   });
 
-  it('should count padding when there\'s none', () => {
+  it('should count padding from start when there\'s none', () => {
     const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => { a[i] = DATA_VALUE; });
 
-    expect(PaddingUtil.countPadding(arrayBuffer, PADDING_VALUE_A)).to.equal(0);
+    expect(PaddingUtil.countPaddingFromStart(arrayBuffer, PADDING_VALUE_A)).to.equal(0);
   });
 
-  it('should count padding when it\'s all padding', () => {
+  it('should count padding from start when it\'s all padding', () => {
     const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => { a[i] = PADDING_VALUE_A; });
 
-    expect(PaddingUtil.countPadding(arrayBuffer, PADDING_VALUE_A)).to.equal(0);
+    expect(PaddingUtil.countPaddingFromStart(arrayBuffer, PADDING_VALUE_A)).to.equal(0);
   });
 
-  it('should count padding', () => {
+  it('should count padding from start', () => {
     const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => { a[i] = ((i < EXTRA_PADDING_COUNT) ? PADDING_VALUE_A : DATA_VALUE); });
 
-    expect(PaddingUtil.countPadding(arrayBuffer, PADDING_VALUE_A)).to.equal(EXTRA_PADDING_COUNT);
+    expect(PaddingUtil.countPaddingFromStart(arrayBuffer, PADDING_VALUE_A)).to.equal(EXTRA_PADDING_COUNT);
   });
 
-  it('should count different values of padding', () => {
+  it('should count different values of padding from the start', () => {
     const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
     const uint8Array = new Uint8Array(arrayBuffer);
     uint8Array.forEach((e, i, a) => { a[i] = ((i < EXTRA_PADDING_COUNT) ? PADDING_VALUE_B : DATA_VALUE); });
 
-    expect(PaddingUtil.countPadding(arrayBuffer, PADDING_VALUE_B)).to.equal(EXTRA_PADDING_COUNT);
+    expect(PaddingUtil.countPaddingFromStart(arrayBuffer, PADDING_VALUE_B)).to.equal(EXTRA_PADDING_COUNT);
+  });
+
+  it('should count padding from end when there\'s none', () => {
+    const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
+    const uint8Array = new Uint8Array(arrayBuffer);
+    uint8Array.forEach((e, i, a) => { a[i] = DATA_VALUE; });
+
+    expect(PaddingUtil.countPaddingFromEnd(arrayBuffer, PADDING_VALUE_A)).to.equal(0);
+  });
+
+  it('should count padding from end when it\'s all padding', () => {
+    const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
+    const uint8Array = new Uint8Array(arrayBuffer);
+    uint8Array.forEach((e, i, a) => { a[i] = PADDING_VALUE_A; });
+
+    expect(PaddingUtil.countPaddingFromEnd(arrayBuffer, PADDING_VALUE_A)).to.equal(0);
+  });
+
+  it('should count padding from end', () => {
+    const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
+    const uint8Array = new Uint8Array(arrayBuffer);
+    uint8Array.forEach((e, i, a) => { a[i] = ((i >= ARRAY_BUFFER_SIZE) ? PADDING_VALUE_A : DATA_VALUE); });
+
+    expect(PaddingUtil.countPaddingFromEnd(arrayBuffer, PADDING_VALUE_A)).to.equal(EXTRA_PADDING_COUNT);
+  });
+
+  it('should count different values of padding from the end', () => {
+    const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE + EXTRA_PADDING_COUNT);
+    const uint8Array = new Uint8Array(arrayBuffer);
+    uint8Array.forEach((e, i, a) => { a[i] = ((i >= ARRAY_BUFFER_SIZE) ? PADDING_VALUE_B : DATA_VALUE); });
+
+    expect(PaddingUtil.countPaddingFromEnd(arrayBuffer, PADDING_VALUE_B)).to.equal(EXTRA_PADDING_COUNT);
   });
 });

--- a/frontend/tests/unit/util/Padding.spec.js
+++ b/frontend/tests/unit/util/Padding.spec.js
@@ -22,7 +22,7 @@ describe('PaddingUtil', () => {
       }
     });
 
-    const padding = PaddingUtil.getPadValueAndCount(arrayBuffer);
+    const padding = PaddingUtil.getPadFromStartValueAndCount(arrayBuffer);
 
     expect(padding.value).to.equal(PADDING_VALUE_A);
     expect(padding.count).to.equal(EXTRA_PADDING_COUNT);
@@ -39,7 +39,7 @@ describe('PaddingUtil', () => {
       }
     });
 
-    const padding = PaddingUtil.getPadValueAndCount(arrayBuffer);
+    const padding = PaddingUtil.getPadFromStartValueAndCount(arrayBuffer);
 
     expect(padding.value).to.equal(PADDING_VALUE_B);
     expect(padding.count).to.equal(EXTRA_PADDING_COUNT);
@@ -58,7 +58,7 @@ describe('PaddingUtil', () => {
       }
     });
 
-    const padding = PaddingUtil.getPadValueAndCount(arrayBuffer);
+    const padding = PaddingUtil.getPadFromStartValueAndCount(arrayBuffer);
 
     expect(padding.value).to.equal(PADDING_VALUE_B);
     expect(padding.count).to.equal(EXTRA_PADDING_COUNT); // The extra byte of padding isn't counted
@@ -71,7 +71,7 @@ describe('PaddingUtil', () => {
       a[i] = DATA_VALUE;
     });
 
-    const padding = PaddingUtil.getPadValueAndCount(arrayBuffer);
+    const padding = PaddingUtil.getPadFromStartValueAndCount(arrayBuffer);
 
     expect(padding.count).to.equal(0);
   });
@@ -83,7 +83,7 @@ describe('PaddingUtil', () => {
       a[i] = PADDING_VALUE_B;
     });
 
-    const padding = PaddingUtil.getPadValueAndCount(arrayBuffer);
+    const padding = PaddingUtil.getPadFromStartValueAndCount(arrayBuffer);
 
     expect(padding.count).to.equal(0);
   });

--- a/frontend/tests/unit/util/Troubleshooting test files.spec.js
+++ b/frontend/tests/unit/util/Troubleshooting test files.spec.js
@@ -69,20 +69,20 @@ describe('Troubleshooting example files', () => {
     const arrayBuffer1 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan).srm');
     const arrayBuffer2 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed.srm');
 
-    expect(PaddingUtil.fileSizeAndPaddingIsSame(arrayBuffer1, arrayBuffer2)).to.equal(false);
+    expect(PaddingUtil.fileSizeAndPaddingFromStartIsSame(arrayBuffer1, arrayBuffer2)).to.equal(false);
   });
 
   it('should notice when 2 files have different sizes', async () => {
     const arrayBuffer1 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed.srm');
     const arrayBuffer2 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) test save all padding.srm');
 
-    expect(PaddingUtil.fileSizeAndPaddingIsSame(arrayBuffer1, arrayBuffer2)).to.equal(true);
+    expect(PaddingUtil.fileSizeAndPaddingFromStartIsSame(arrayBuffer1, arrayBuffer2)).to.equal(true);
   });
 
   it('should notice when 2 files have the same size but different padding', async () => {
     const arrayBuffer1 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed extra padding at end.srm');
     const arrayBuffer2 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed extra padding at start.srm');
 
-    expect(PaddingUtil.fileSizeAndPaddingIsSame(arrayBuffer1, arrayBuffer2)).to.equal(false);
+    expect(PaddingUtil.fileSizeAndPaddingFromStartIsSame(arrayBuffer1, arrayBuffer2)).to.equal(false);
   });
 });

--- a/frontend/tests/unit/util/Troubleshooting test files.spec.js
+++ b/frontend/tests/unit/util/Troubleshooting test files.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import Troubleshooting from '@/util/Troubleshooting';
+import PaddingUtil from '@/util/Padding';
 
 import ArrayBufferUtil from '#/util/ArrayBuffer';
 
@@ -20,7 +20,7 @@ describe('Troubleshooting example files', () => {
     const testSaveData = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed.srm');
     const correctSaveData = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed.srm');
 
-    const fixedData = Troubleshooting.attemptFix(testSaveData, brokenSaveData);
+    const fixedData = PaddingUtil.attemptFix(testSaveData, brokenSaveData);
 
     expect(ArrayBufferUtil.arrayBuffersEqual(fixedData, correctSaveData)).to.equal(true);
   });
@@ -30,7 +30,7 @@ describe('Troubleshooting example files', () => {
     const testSaveData = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan).srm');
     const correctSaveData = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan).srm');
 
-    const fixedData = Troubleshooting.attemptFix(testSaveData, brokenSaveData);
+    const fixedData = PaddingUtil.attemptFix(testSaveData, brokenSaveData);
 
     expect(ArrayBufferUtil.arrayBuffersEqual(fixedData, correctSaveData)).to.equal(true);
   });
@@ -40,7 +40,7 @@ describe('Troubleshooting example files', () => {
     const testSaveData = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed.srm');
     const correctSaveData = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed.srm');
 
-    const fixedData = Troubleshooting.attemptFix(testSaveData, brokenSaveData);
+    const fixedData = PaddingUtil.attemptFix(testSaveData, brokenSaveData);
 
     expect(ArrayBufferUtil.arrayBuffersEqual(fixedData, correctSaveData)).to.equal(true);
   });
@@ -50,7 +50,7 @@ describe('Troubleshooting example files', () => {
     const testSaveData = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed extra padding at end.srm');
     const correctSaveData = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed extra padding at end.srm');
 
-    const fixedData = Troubleshooting.attemptFix(testSaveData, brokenSaveData);
+    const fixedData = PaddingUtil.attemptFix(testSaveData, brokenSaveData);
 
     expect(ArrayBufferUtil.arrayBuffersEqual(fixedData, correctSaveData)).to.equal(true);
   });
@@ -60,7 +60,7 @@ describe('Troubleshooting example files', () => {
     const testSaveData = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) test save all padding.srm');
     const correctSaveData = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed.srm');
 
-    const fixedData = Troubleshooting.attemptFix(testSaveData, brokenSaveData);
+    const fixedData = PaddingUtil.attemptFix(testSaveData, brokenSaveData);
 
     expect(ArrayBufferUtil.arrayBuffersEqual(fixedData, correctSaveData)).to.equal(true);
   });
@@ -69,20 +69,20 @@ describe('Troubleshooting example files', () => {
     const arrayBuffer1 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan).srm');
     const arrayBuffer2 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed.srm');
 
-    expect(Troubleshooting.fileSizeAndPaddingIsSame(arrayBuffer1, arrayBuffer2)).to.equal(false);
+    expect(PaddingUtil.fileSizeAndPaddingIsSame(arrayBuffer1, arrayBuffer2)).to.equal(false);
   });
 
   it('should notice when 2 files have different sizes', async () => {
     const arrayBuffer1 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed.srm');
     const arrayBuffer2 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) test save all padding.srm');
 
-    expect(Troubleshooting.fileSizeAndPaddingIsSame(arrayBuffer1, arrayBuffer2)).to.equal(true);
+    expect(PaddingUtil.fileSizeAndPaddingIsSame(arrayBuffer1, arrayBuffer2)).to.equal(true);
   });
 
   it('should notice when 2 files have the same size but different padding', async () => {
     const arrayBuffer1 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed extra padding at end.srm');
     const arrayBuffer2 = await ArrayBufferUtil.readArrayBuffer('./tests/unit/util/data/Tomato Adventure (Japan) fixed extra padding at start.srm');
 
-    expect(Troubleshooting.fileSizeAndPaddingIsSame(arrayBuffer1, arrayBuffer2)).to.equal(false);
+    expect(PaddingUtil.fileSizeAndPaddingIsSame(arrayBuffer1, arrayBuffer2)).to.equal(false);
   });
 });


### PR DESCRIPTION
- Unpad MiSTer Genesis files when converting to raw
- Pad MiSTer Genesis files when just passing them through
- Rename `Troubleshooting` to `PaddingUtil`
- A bunch of clarification in `PaddingUtil` about whether padding is being counted from the beginning or end of the data
- Add MiSTer to the site nav (as "Beta") since Genesis conversion is verified working
- Fix incorrect rendering on the nav when retron 5 cart save erase is active
- Update the site description for google
