### PR TITLE
Added support for converting NES and SNES games to/from MiSTer

### DIFF
--- a/frontend/src/components/ConvertMister.vue
+++ b/frontend/src/components/ConvertMister.vue
@@ -100,6 +100,7 @@ import OutputFilename from './OutputFilename.vue';
 import ConversionDirection from './ConversionDirection.vue';
 import MisterPlatform from './MisterPlatform.vue';
 
+import MisterSnesSaveData from '../save-formats/Mister/Snes';
 import MisterGenesisSaveData from '../save-formats/Mister/Genesis';
 import MisterPs1SaveData from '../save-formats/Mister/Ps1';
 
@@ -139,6 +140,11 @@ export default {
     misterPlatformChanged() {
       if (this.misterPlatform !== null) {
         switch (this.misterPlatform) {
+          case 'Mister-SNES': {
+            this.misterPlatformClass = MisterSnesSaveData;
+            break;
+          }
+
           case 'Mister-MD': {
             this.misterPlatformClass = MisterGenesisSaveData;
             break;

--- a/frontend/src/components/ConvertMister.vue
+++ b/frontend/src/components/ConvertMister.vue
@@ -100,6 +100,7 @@ import OutputFilename from './OutputFilename.vue';
 import ConversionDirection from './ConversionDirection.vue';
 import MisterPlatform from './MisterPlatform.vue';
 
+import MisterNesSaveData from '../save-formats/Mister/Nes';
 import MisterSnesSaveData from '../save-formats/Mister/Snes';
 import MisterGenesisSaveData from '../save-formats/Mister/Genesis';
 import MisterPs1SaveData from '../save-formats/Mister/Ps1';
@@ -140,6 +141,11 @@ export default {
     misterPlatformChanged() {
       if (this.misterPlatform !== null) {
         switch (this.misterPlatform) {
+          case 'Mister-NES': {
+            this.misterPlatformClass = MisterNesSaveData;
+            break;
+          }
+
           case 'Mister-SNES': {
             this.misterPlatformClass = MisterSnesSaveData;
             break;

--- a/frontend/src/components/MisterPlatform.vue
+++ b/frontend/src/components/MisterPlatform.vue
@@ -53,8 +53,8 @@ export default {
 
       options: [
         { value: null, text: 'Choose platform', disabled: true },
-        { value: 'Mister-NES', text: 'NES', disabled: true },
-        { value: 'Mister-SNES', text: 'Super NES', disabled: true },
+        { value: 'Mister-NES', text: 'NES' },
+        { value: 'Mister-SNES', text: 'Super NES' },
         // { value: 'Mister-N64', text: 'Nintendo 64', disabled: true },
         // { value: 'Mister-GCN', text: 'GameCube', disabled: true },
         { value: 'Mister-GB', text: 'Game Boy/Game Boy Color', disabled: true },

--- a/frontend/src/save-formats/Mister/Nes.js
+++ b/frontend/src/save-formats/Mister/Nes.js
@@ -1,0 +1,54 @@
+/*
+The MiSTer saves NES data as a regular raw file, but most files appear to be expanded out to 32kB, instead of the usual ~8kB, with garbage data.
+Some MiSTER NES saves are larger than 32kB -- I've seen a few 128kB ones.
+
+Loading these larger files straight in an emulator seems to work fine. But let's pad out an emulator file to 32kB when converting to MiSTer just to be nice
+*/
+
+import PaddingUtil from '../../util/Padding';
+
+const MISTER_MINIMUM_FILE_SIZE = 32768;
+const MISTER_PADDING_VALUE = 0x00; // Not sure what to choose for padding, given that actual MiSTer files are filled with garbage data
+
+function padArrayBuffer(inputArrayBuffer) {
+  const padding = {
+    value: MISTER_PADDING_VALUE,
+    count: Math.max(MISTER_MINIMUM_FILE_SIZE - inputArrayBuffer.byteLength, 0),
+  };
+
+  return PaddingUtil.addPaddingToEnd(inputArrayBuffer, padding);
+}
+
+export default class MisterNesSaveData {
+  static getMisterFileExtension() {
+    return 'sav';
+  }
+
+  static getRawFileExtension() {
+    return 'srm';
+  }
+
+  static createFromMisterData(misterArrayBuffer) {
+    // Just copy it straight over, because we don't know what size to truncate to: not all NES saves are 8kB
+    return new MisterNesSaveData(misterArrayBuffer, misterArrayBuffer);
+  }
+
+  static createFromRawData(rawArrayBuffer) {
+    // Pad our file out to the minimum MiSTer size, just to be nice
+    return new MisterNesSaveData(rawArrayBuffer, padArrayBuffer(rawArrayBuffer));
+  }
+
+  // This constructor creates a new object from a binary representation of a MiSTer save data file
+  constructor(rawArrayBuffer, misterArrayBuffer) {
+    this.rawArrayBuffer = rawArrayBuffer;
+    this.misterArrayBuffer = misterArrayBuffer;
+  }
+
+  getRawArrayBuffer() {
+    return this.rawArrayBuffer;
+  }
+
+  getMisterArrayBuffer() {
+    return this.misterArrayBuffer;
+  }
+}

--- a/frontend/src/save-formats/Mister/Snes.js
+++ b/frontend/src/save-formats/Mister/Snes.js
@@ -1,0 +1,35 @@
+/*
+The MiSTer saves SNES data as just the raw data of the correct size: no transformation or padding required
+*/
+
+export default class MisterSnesSaveData {
+  static getMisterFileExtension() {
+    return 'sav';
+  }
+
+  static getRawFileExtension() {
+    return 'srm';
+  }
+
+  static createFromMisterData(misterArrayBuffer) {
+    return new MisterSnesSaveData(misterArrayBuffer, misterArrayBuffer);
+  }
+
+  static createFromRawData(rawArrayBuffer) {
+    return new MisterSnesSaveData(rawArrayBuffer, rawArrayBuffer);
+  }
+
+  // This constructor creates a new object from a binary representation of a MiSTer save data file
+  constructor(rawArrayBuffer, misterArrayBuffer) {
+    this.rawArrayBuffer = rawArrayBuffer;
+    this.misterArrayBuffer = misterArrayBuffer;
+  }
+
+  getRawArrayBuffer() {
+    return this.rawArrayBuffer;
+  }
+
+  getMisterArrayBuffer() {
+    return this.misterArrayBuffer;
+  }
+}


### PR DESCRIPTION
SNES saves appear to be exactly the same as their cartridge counterparts, but for NES games I had to guess because the MiSTer files are generally larger than their cartridge counterparts (cart = generally 8k, MiSTer NES = generally 32k), and filled with garbage data.

They appear to have the good data at the start of the file, and loading the entire file, garbage and all, into an emulator worked fine. So, passed it straight through when converting from MiSTer, and padded it out to 32k when converting to MiSTer