### PR TITLE
Various tweaks to the MiSTer page

### DIFF
--- a/frontend/src/components/ConvertMister.vue
+++ b/frontend/src/components/ConvertMister.vue
@@ -76,6 +76,16 @@
           </b-button>
         </b-col>
       </b-row>
+      <b-row>
+        <b-col>
+          <div class="help">
+            Greyed-out platforms currently do not fully support saving on the MiSTer.
+          </div>
+          <div class="help">
+            Is this information incorrect or out of date? Please <router-link to="/about">contact us</router-link>
+          </div>
+        </b-col>
+      </b-row>
     </b-container>
   </div>
 </template>

--- a/frontend/src/components/ConvertMister.vue
+++ b/frontend/src/components/ConvertMister.vue
@@ -76,16 +76,6 @@
           </b-button>
         </b-col>
       </b-row>
-      <b-row>
-        <b-col>
-          <div class="help">
-            Greyed-out platforms currently do not fully support saving on the MiSTer.
-          </div>
-          <div class="help">
-            Is this information incorrect or out of date? Please <router-link to="/about">contact us</router-link>
-          </div>
-        </b-col>
-      </b-row>
     </b-container>
   </div>
 </template>

--- a/frontend/src/components/MisterPlatform.vue
+++ b/frontend/src/components/MisterPlatform.vue
@@ -74,7 +74,7 @@ export default {
         /* Commented out differently because we may put it back when we get more information
         { value: 'Mister-WS', text: 'WonderSwan/WonderSwan Color', disabled: true }, // Files created by the MiSTer are of several different sizes, each 0x200 bytes more than a power of two. Don't currently have sufficient test data to determine whether they're loadable by an emulator or vice versa
         */
-        { value: 'Mister-AJ', text: 'Jaguar', disabled: true }, // Core is in early stages, saving may not be supported yet
+        // { value: 'Mister-AJ', text: 'Jaguar', disabled: true }, // Core is in early stages, saving may not be supported yet
         // { value: 'Mister-AL', text: 'Lynx', disabled: true }, // No commercial releases for Lynx with saving. A few homebrews do, but saving not implmented on the MiSTer core
       ],
     };

--- a/frontend/src/components/MisterPlatform.vue
+++ b/frontend/src/components/MisterPlatform.vue
@@ -58,18 +58,22 @@ export default {
         // { value: 'Mister-N64', text: 'Nintendo 64', disabled: true }, // MiSTer hardware not powerful enough
         // { value: 'Mister-GCN', text: 'GameCube', disabled: true }, // MiSTer hardware not powerful enough
         { value: 'Mister-GB', text: 'Game Boy/Game Boy Color' },
-        { value: 'Mister-GBA', text: 'Game Boy Advance' },
+        { value: 'Mister-GBA', text: 'Game Boy Advance', disabled: true }, // The MiSTer files for some games (e.g. Metroid Fusion, Castlevania - Aria of Sorrow) are too small and don't contain all of the necessary data. The core may not have saving working for all types of saves.
         { value: 'Mister-GG', text: 'Game Gear' },
         { value: 'Mister-SMS', text: 'Sega Master System' },
         { value: 'Mister-MD', text: 'Sega Genesis/Mega Drive' },
-        { value: 'Mister-MCD', text: 'Sega CD/Mega CD', disabled: true },
+        /* Commented out differently because we may put it back when we get more information
+        { value: 'Mister-MCD', text: 'Sega CD/Mega CD', disabled: true }, // The MiSTer file created was too big. It contained a similar footer to the file created by the emulator, but could not be loaded in the emulator. Unsure what to do here: can the middle just be cut out?
+        */
         // { value: 'Mister-32X', text: 'Sega 32X', disabled: true }, // Currently no core for this, might be created after the Saturn one
         // { value: 'Mister-SAT', text: 'Sega Saturn', disabled: true }, // Core is currently in development
         // { value: 'Mister-DC', text: 'Dreamcast', disabled: true }, // MiSTer hardware not powerful enough
         { value: 'Mister-PCE', text: 'Turbografx-16/PC Engine' },
         { value: 'Mister-PS1', text: 'PlayStation 1' },
         // { value: 'Mister-PS2', text: 'PlayStation 2', disabled: true }, // MiSTer hardware not powerful enough
-        { value: 'Mister-WS', text: 'WonderSwan/WonderSwan Color', disabled: true },
+        /* Commented out differently because we may put it back when we get more information
+        { value: 'Mister-WS', text: 'WonderSwan/WonderSwan Color', disabled: true }, // Files created by the MiSTer are of several different sizes, each 0x200 bytes more than a power of two. Don't currently have sufficient test data to determine whether they're loadable by an emulator or vice versa
+        */
         { value: 'Mister-AJ', text: 'Jaguar', disabled: true }, // Core is in early stages, saving may not be supported yet
         // { value: 'Mister-AL', text: 'Lynx', disabled: true }, // No commercial releases for Lynx with saving. A few homebrews do, but saving not implmented on the MiSTer core
       ],

--- a/frontend/src/components/MisterPlatform.vue
+++ b/frontend/src/components/MisterPlatform.vue
@@ -49,7 +49,7 @@ export default {
   },
   data() {
     return {
-      // Commented out ones are platforms we support elsewhere on the site but are current;y available on the MiSTer
+      // Commented out ones are platforms we support elsewhere on the site but are currently available on the MiSTer
 
       options: [
         { value: null, text: 'Choose platform', disabled: true },

--- a/frontend/src/components/MisterPlatform.vue
+++ b/frontend/src/components/MisterPlatform.vue
@@ -49,29 +49,29 @@ export default {
   },
   data() {
     return {
-      // Commented out ones are platforms we support elsewhere on the site but are not possible to emulate on the MiSTer
+      // Commented out ones are platforms we support elsewhere on the site but are current;y available on the MiSTer
 
       options: [
         { value: null, text: 'Choose platform', disabled: true },
         { value: 'Mister-NES', text: 'NES' },
         { value: 'Mister-SNES', text: 'Super NES' },
-        // { value: 'Mister-N64', text: 'Nintendo 64', disabled: true },
-        // { value: 'Mister-GCN', text: 'GameCube', disabled: true },
+        // { value: 'Mister-N64', text: 'Nintendo 64', disabled: true }, // MiSTer hardware not powerful enough
+        // { value: 'Mister-GCN', text: 'GameCube', disabled: true }, // MiSTer hardware not powerful enough
         { value: 'Mister-GB', text: 'Game Boy/Game Boy Color' },
         { value: 'Mister-GBA', text: 'Game Boy Advance' },
         { value: 'Mister-GG', text: 'Game Gear' },
         { value: 'Mister-SMS', text: 'Sega Master System' },
         { value: 'Mister-MD', text: 'Sega Genesis/Mega Drive' },
         { value: 'Mister-MCD', text: 'Sega CD/Mega CD', disabled: true },
-        { value: 'Mister-32X', text: 'Sega 32X', disabled: true },
-        { value: 'Mister-SAT', text: 'Sega Saturn', disabled: true },
-        // { value: 'Mister-DC', text: 'Dreamcast', disabled: true },
+        // { value: 'Mister-32X', text: 'Sega 32X', disabled: true }, // Currently no core for this, might be created after the Saturn one
+        // { value: 'Mister-SAT', text: 'Sega Saturn', disabled: true }, // Core is currently in development
+        // { value: 'Mister-DC', text: 'Dreamcast', disabled: true }, // MiSTer hardware not powerful enough
         { value: 'Mister-PCE', text: 'Turbografx-16/PC Engine' },
         { value: 'Mister-PS1', text: 'PlayStation 1' },
-        // { value: 'Mister-PS2', text: 'PlayStation 2', disabled: true },
+        // { value: 'Mister-PS2', text: 'PlayStation 2', disabled: true }, // MiSTer hardware not powerful enough
         { value: 'Mister-WS', text: 'WonderSwan/WonderSwan Color', disabled: true },
-        { value: 'Mister-AJ', text: 'Jaguar', disabled: true },
-        { value: 'Mister-AL', text: 'Lynx', disabled: true },
+        { value: 'Mister-AJ', text: 'Jaguar', disabled: true }, // Core is in early stages, saving may not be supported yet
+        // { value: 'Mister-AL', text: 'Lynx', disabled: true }, // No commercial releases for Lynx with saving. A few homebrews do, but saving not implmented on the MiSTer core
       ],
     };
   },

--- a/frontend/src/components/MisterPlatform.vue
+++ b/frontend/src/components/MisterPlatform.vue
@@ -58,7 +58,7 @@ export default {
         // { value: 'Mister-N64', text: 'Nintendo 64', disabled: true }, // MiSTer hardware not powerful enough
         // { value: 'Mister-GCN', text: 'GameCube', disabled: true }, // MiSTer hardware not powerful enough
         { value: 'Mister-GB', text: 'Game Boy/Game Boy Color' },
-        { value: 'Mister-GBA', text: 'Game Boy Advance', disabled: true }, // The MiSTer files for some games (e.g. Metroid Fusion, Castlevania - Aria of Sorrow) are too small and don't contain all of the necessary data. The core may not have saving working for all types of saves.
+        { value: 'Mister-GBA', text: 'Game Boy Advance' },
         { value: 'Mister-GG', text: 'Game Gear' },
         { value: 'Mister-SMS', text: 'Sega Master System' },
         { value: 'Mister-MD', text: 'Sega Genesis/Mega Drive' },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -6,7 +6,7 @@ Vue.use(VueRouter);
 const routes = [
   {
     path: '/',
-    redirect: '/retron-5',
+    redirect: '/mister',
   },
   {
     path: '/retron-5',

--- a/frontend/src/save-formats/Mister/GameGear.js
+++ b/frontend/src/save-formats/Mister/GameGear.js
@@ -1,6 +1,6 @@
 /*
-I don't have any test save files for Game Gear, so I'm just going to assume for now that we pass the file straight through
-in both directions
+The MiSTer makes saves that are 64kB in size and the emulator I tried makes saves that are 32kB. Each seems able to load the other's save.
+I'm not sure which of the two sizes is "correct", so I'm just going to leave everything alone.
 
 A list of Game Gear games that support saving can be found here:
 https://segaretro.org/Battery_backup#Game_Gear

--- a/frontend/src/save-formats/Mister/GameboyAdvance.js
+++ b/frontend/src/save-formats/Mister/GameboyAdvance.js
@@ -1,5 +1,11 @@
 /*
-The MiSTer saves GBA data as just the raw data of the correct size: no transformation or padding required
+In the test files I was provided for GBA, the mister files looked "too short": the ones I had from a Retron 5 were longer and
+had data past where the mister ones ended.
+
+But the info for the GBA core seems to indicate that saving works fully and any remaining issues with the core
+are minor and cosmetic: https://github.com/MiSTer-devel/GBA_MiSTer
+
+So I'm just going to assume that no transformation is needed for GBA files until I hear otherwise.
 */
 
 export default class MisterGameboyAdvanceSaveData {


### PR DESCRIPTION
- Made the mister page the default route
- Reenabled GBA after reading the core's readme file. Added notes to its conversion file
- Removed some platforms that I haven't been able to get info about yet (WonderSwan, Sega CD)
- Added notes to the Game Gear conversion file
- Added notes to the other mister platforms that are currently commented out