### PR TITLE
Fixed null descriptions on some PS1 screens, and misleading PSP error message

### DIFF
--- a/frontend/src/components/ConvertPs1Emulator.vue
+++ b/frontend/src/components/ConvertPs1Emulator.vue
@@ -58,7 +58,7 @@
             />
             <file-list
               :display="this.memcardSaveData !== null"
-              :files="this.memcardSaveData ? this.memcardSaveData.getSaveFiles() : []"
+              :files="this.getFileListNames()"
               :enabled="false"
             />
           </div>

--- a/frontend/src/components/ConvertPs1Psp.vue
+++ b/frontend/src/components/ConvertPs1Psp.vue
@@ -69,7 +69,7 @@
             />
             <file-list
               :display="this.pspSaveData !== null"
-              :files="this.pspSaveData ? this.pspSaveData.getSaveFiles() : []"
+              :files="this.getFileListNames()"
               :enabled="false"
             />
           </div>

--- a/frontend/src/components/DecryptPsp.vue
+++ b/frontend/src/components/DecryptPsp.vue
@@ -209,6 +209,7 @@ export default {
       return this.pspDataArrayBuffer && this.gamekeyArrayBuffer && this.outputFilename && this.paramSfoArrayBuffer;
     },
     convertFile() {
+      this.errorMessage = null;
       if (this.conversionDirection === 'convertToEmulator') {
         // Decrypting
         try {
@@ -233,8 +234,8 @@ export default {
 
           saveAs(outputBlobParamSfo, 'PARAM.SFO'); // Frustratingly, in Firefox the dialog says "from: blob:" and apparently this can't be changed: https://github.com/eligrey/FileSaver.js/issues/101
         } catch (e) {
-          this.errorMessage = 'Encountered an error trying to encrypt file. Please double-check that you supplied an unencrypted PSP save file,'
-          + ' the correct PARAM.SFO file, and a 16 byte game key file';
+          this.errorMessage = 'Encountered an error trying to encrypt file. Please double-check that you entered an output filename that matches the original file '
+          + ' on your PSP, and that supplied an unencrypted PSP save file, the correct PARAM.SFO file, and a 16 byte game key file';
         }
       }
     },


### PR DESCRIPTION
- Fixed descriptions reading `null` when loading individual saves on the PS1's PSP and emulator screens
- Improved error message when PSP encryption fails to include the most common reason for the failure (bad output filename)
- Made the error message disappear on the PSP encryption screen when trying to encrypt again

Fixes https://github.com/euan-forrester/save-file-converter/issues/121
Fixes https://github.com/euan-forrester/save-file-converter/issues/122