### PR TITLE
Made the mega sd sms conversion be able to accept raw files

### DIFF
--- a/frontend/src/save-formats/FlashCarts/Genesis/MegaSD/Genesis.js
+++ b/frontend/src/save-formats/FlashCarts/Genesis/MegaSD/Genesis.js
@@ -32,13 +32,13 @@ const RAW_SRAM_MIN_SIZE = 16384; // 8kB, byte expanded
 // to see if it's an EEPROM save because ome games if saved early might not have much data, and so we might get an incorrect result.
 
 function isNewStyleSave(flashCartArrayBuffer) {
-  try { // eslint-disable-line import/no-named-as-default, import/no-named-as-default-member
+  try {
     Util.checkMagic(flashCartArrayBuffer, MAGIC_OFFSET, MAGIC, MAGIC_ENCODING);
-
-    return ((flashCartArrayBuffer.byteLength > MAGIC.length) && MathUtil.isPowerOf2(flashCartArrayBuffer.byteLength - MAGIC.length));
   } catch (e) {
     return false;
   }
+
+  return ((flashCartArrayBuffer.byteLength > MAGIC.length) && MathUtil.isPowerOf2(flashCartArrayBuffer.byteLength - MAGIC.length));
 }
 
 function isOldStyleSave(flashCartArrayBuffer) {

--- a/frontend/src/save-formats/FlashCarts/Genesis/MegaSD/SMS.js
+++ b/frontend/src/save-formats/FlashCarts/Genesis/MegaSD/SMS.js
@@ -1,6 +1,8 @@
 // SMS files on the Mega SD appear to just have "BUP2" prepended to the start of the file.
 // This is the same as the "new style" (i.e. recent firmware) of Genesis saves on the device.
 // I'm not sure if there's an "old style" for SMS saves on the Mega SD.
+//
+// We're going to make this also be able to load raw saves in case that was the "old style" (if there was even an "old style"!)
 
 import SaveFilesUtil from '../../../../util/SaveFiles';
 import MathUtil from '../../../../util/Math';
@@ -10,22 +12,47 @@ const MAGIC = 'BUP2';
 const MAGIC_OFFSET = 0;
 const MAGIC_ENCODING = 'US-ASCII';
 
+function isNewStyleSave(flashCartArrayBuffer) {
+  try {
+    Util.checkMagic(flashCartArrayBuffer, MAGIC_OFFSET, MAGIC, MAGIC_ENCODING);
+  } catch (e) {
+    return false;
+  }
+
+  return ((flashCartArrayBuffer.byteLength > MAGIC.length) && MathUtil.isPowerOf2(flashCartArrayBuffer.byteLength - MAGIC.length));
+}
+
+function isOldStyleSave(flashCartArrayBuffer) {
+  return MathUtil.isPowerOf2(flashCartArrayBuffer.byteLength);
+}
+
+function convertFromNewStyleToRaw(flashCartArrayBuffer) {
+  return flashCartArrayBuffer.slice(MAGIC.length);
+}
+
+function convertFromRawToNewStyle(rawArrayBuffer) {
+  const textEncoder = new TextEncoder(MAGIC_ENCODING);
+  const magicArrayBuffer = Util.bufferToArrayBuffer(textEncoder.encode(MAGIC));
+
+  return Util.concatArrayBuffers([magicArrayBuffer, rawArrayBuffer]);
+}
+
 export default class GenesisMegaSdSmsFlashCartSaveData {
   static createFromFlashCartData(flashCartArrayBuffer) {
-    Util.checkMagic(flashCartArrayBuffer, MAGIC_OFFSET, MAGIC, MAGIC_ENCODING);
+    if (isNewStyleSave(flashCartArrayBuffer)) {
+      return new GenesisMegaSdSmsFlashCartSaveData(flashCartArrayBuffer, convertFromNewStyleToRaw(flashCartArrayBuffer));
+    }
 
-    if ((flashCartArrayBuffer.byteLength > MAGIC.length) && MathUtil.isPowerOf2(flashCartArrayBuffer.byteLength - MAGIC.length)) {
-      return new GenesisMegaSdSmsFlashCartSaveData(flashCartArrayBuffer, flashCartArrayBuffer.slice(MAGIC.length));
+    if (isOldStyleSave(flashCartArrayBuffer)) {
+      const rawArrayBuffer = flashCartArrayBuffer; // In the "old sty;e", the flash cart data is just raw data
+      return new GenesisMegaSdSmsFlashCartSaveData(convertFromRawToNewStyle(rawArrayBuffer), rawArrayBuffer);
     }
 
     throw new Error('This does not appear to be a Mega SD Sega Master System save file');
   }
 
   static createFromRawData(rawArrayBuffer) {
-    const textEncoder = new TextEncoder(MAGIC_ENCODING);
-    const magicArrayBuffer = Util.bufferToArrayBuffer(textEncoder.encode(MAGIC));
-
-    return new GenesisMegaSdSmsFlashCartSaveData(Util.concatArrayBuffers([magicArrayBuffer, rawArrayBuffer]), rawArrayBuffer);
+    return new GenesisMegaSdSmsFlashCartSaveData(convertFromRawToNewStyle(rawArrayBuffer), rawArrayBuffer);
   }
 
   static createWithNewSize(flashCartSaveData, newSize) {

--- a/frontend/tests/unit/save-formats/FlashCarts/Genesis/MegaSD/SMS.spec.js
+++ b/frontend/tests/unit/save-formats/FlashCarts/Genesis/MegaSD/SMS.spec.js
@@ -18,12 +18,24 @@ describe('Flash cart - Genesis - Mega SD - SMS', () => {
     expect(ArrayBufferUtil.arrayBuffersEqual(flashCartSaveData.getFlashCartArrayBuffer(), flashCartArrayBuffer)).to.equal(true);
   });
 
-  it('should convert a Mega SD SMS save to raw format', async () => {
+  it('should convert a new style Mega SD SMS save to raw format', async () => {
     const flashCartArrayBuffer = await ArrayBufferUtil.readArrayBuffer(MEGA_SD_FILENAME);
     const rawArrayBuffer = await ArrayBufferUtil.readArrayBuffer(RAW_FILENAME);
 
     const flashCartSaveData = GenesisMegaaSdSmsFlashCartSaveData.createFromFlashCartData(flashCartArrayBuffer);
 
     expect(ArrayBufferUtil.arrayBuffersEqual(flashCartSaveData.getRawArrayBuffer(), rawArrayBuffer)).to.equal(true);
+  });
+
+  it('should convert an old style Mega SD SMS save to raw format', async () => {
+    const oldStyleFlashCartArrayBuffer = await ArrayBufferUtil.readArrayBuffer(RAW_FILENAME); // Repurpose our raw save as an "old style" save
+    const newStyleFlashCartArrayBuffer = await ArrayBufferUtil.readArrayBuffer(MEGA_SD_FILENAME);
+
+    const rawArrayBuffer = oldStyleFlashCartArrayBuffer;
+
+    const flashCartSaveData = GenesisMegaaSdSmsFlashCartSaveData.createFromFlashCartData(oldStyleFlashCartArrayBuffer);
+
+    expect(ArrayBufferUtil.arrayBuffersEqual(flashCartSaveData.getRawArrayBuffer(), rawArrayBuffer)).to.equal(true);
+    expect(ArrayBufferUtil.arrayBuffersEqual(flashCartSaveData.getFlashCartArrayBuffer(), newStyleFlashCartArrayBuffer)).to.equal(true);
   });
 });


### PR DESCRIPTION
We don't know if there was an "old style" for Mega SD SMS files, like there seems to have been for Genesis files, but let's assume that there was one and it was equivalent to a raw file. This seems in line with the "old style" Genesis files, which were very similar to raw files, just expanded with `0xFF` instead of `0x00`