### PR TITLE
Split flash cart selection into 2 dropdowns

### DIFF
--- a/frontend/src/components/FlashCartType.vue
+++ b/frontend/src/components/FlashCartType.vue
@@ -1,10 +1,7 @@
 <template>
     <div>
     <b-row no-gutters align-h="start" align-v="center">
-      <b-col cols=4 class="text-left text-label">
-        Flash cart type:
-      </b-col>
-      <b-col cols=7 sm=8>
+      <b-col cols=11 sm=12>
         <div>
           <b-form-select
             v-model="flashCartType"
@@ -21,10 +18,7 @@
       </b-col>
     </b-row>
     <b-row no-gutters align-h="start" align-v="center">
-     <b-col cols=4 class="text-left text-label">
-        Game type:
-      </b-col>
-      <b-col cols=7 sm=8>
+      <b-col cols=11 sm=12>
         <div>
           <b-form-select
             v-model="platformType"
@@ -93,45 +87,45 @@ export default {
       platformType: null,
       flashCartTypes: [
         { value: null, text: 'Choose flash cart type', disabled: true },
-        { value: 'NES', text: 'NES' },
-        { value: 'SNES', text: 'SNES' },
-        { value: 'GB', text: 'Gameboy/Gameboy Color' },
-        { value: 'GBA', text: 'Gameboy Advance' },
-        { value: 'GenesisEverdrive', text: 'Genesis (Everdrive)' },
-        { value: 'GenesisMegaSD', text: 'Genesis (Mega SD)' },
-        { value: 'N64', text: 'Nintendo 64' },
+        { value: 'NES', text: 'NES cart' },
+        { value: 'SNES', text: 'SNES cart' },
+        { value: 'GB', text: 'Gameboy/Gameboy Color cart' },
+        { value: 'GBA', text: 'Gameboy Advance cart' },
+        { value: 'GenesisEverdrive', text: 'Genesis cart (Everdrive)' },
+        { value: 'GenesisMegaSD', text: 'Genesis cart (Mega SD)' },
+        { value: 'N64', text: 'Nintendo 64 cart' },
       ],
 
       platformTypes: {
         NES: [
-          { value: 'FlashCart-NES', text: 'NES' },
+          { value: 'FlashCart-NES', text: 'NES game' },
         ],
         SNES: [
-          { value: 'FlashCart-SNES', text: 'SNES' },
+          { value: 'FlashCart-SNES', text: 'SNES game' },
         ],
         GB: [
-          { value: 'FlashCart-GB', text: 'Gameboy/Gameboy Color' },
+          { value: 'FlashCart-GB', text: 'Gameboy/Gameboy Color game' },
         ],
         GBA: [
           { value: null, text: 'Choose game type', disabled: true },
-          { value: 'FlashCart-GBA', text: 'Gameboy Advance' },
-          { value: 'FlashCart-GoombaEmulator', text: 'GB/GBC (Goomba emulator)' },
-          { value: 'FlashCart-PocketNesEmulator', text: 'NES (PocketNES emulator)' },
-          { value: 'FlashCart-SMSAdvanceEmulator', text: 'SMS (SMSAdvance emulator)' },
+          { value: 'FlashCart-GBA', text: 'Gameboy Advance game' },
+          { value: 'FlashCart-GoombaEmulator', text: 'GB/GBC game (Goomba emulator)' },
+          { value: 'FlashCart-PocketNesEmulator', text: 'NES game (PocketNES emulator)' },
+          { value: 'FlashCart-SMSAdvanceEmulator', text: 'SMS game (SMSAdvance emulator)' },
         ],
         GenesisEverdrive: [
           { value: null, text: 'Choose game type', disabled: true },
-          { value: 'FlashCart-GenesisEverdrive', text: 'Genesis' },
-          { value: 'FlashCart-NESGenesisEverdrive', text: 'NES' },
-          { value: 'FlashCart-SMSGenesisEverdrive', text: 'SMS' },
+          { value: 'FlashCart-GenesisEverdrive', text: 'Genesis game' },
+          { value: 'FlashCart-NESGenesisEverdrive', text: 'NES game' },
+          { value: 'FlashCart-SMSGenesisEverdrive', text: 'SMS game' },
         ],
         GenesisMegaSD: [
           { value: null, text: 'Choose game type', disabled: true },
-          { value: 'FlashCart-GenesisMegaSD', text: 'Genesis' },
-          { value: 'FlashCart-SMSGenesisMegaSD', text: 'SMS' },
+          { value: 'FlashCart-GenesisMegaSD', text: 'Genesis game' },
+          { value: 'FlashCart-SMSGenesisMegaSD', text: 'SMS game' },
         ],
         N64: [
-          { value: 'FlashCart-N64', text: 'Nintendo 64' },
+          { value: 'FlashCart-N64', text: 'Nintendo 64 game' },
         ],
       },
     };

--- a/frontend/src/components/FlashCartType.vue
+++ b/frontend/src/components/FlashCartType.vue
@@ -17,23 +17,25 @@
         </div>
       </b-col>
     </b-row>
-    <b-row no-gutters align-h="start" align-v="center">
-      <b-col cols=11 sm=12>
-        <div>
-          <b-form-select
-            v-model="platformType"
-            v-on:input="$emit('input', $event)"
-            :options="this.platformTypes[this.flashCartType]"
-            :disabled="disabled"
-          />
-          <help-button
-            popover-text="Select the type of game that the save is for."
-            :id="`${this.id}-platform-type`"
-            class="help-button"
-          />
-        </div>
-      </b-col>
-    </b-row>
+    <div v-if="(this.flashCartType !== null) && (this.platformTypes[this.flashCartType].length > 1)">
+      <b-row no-gutters align-h="start" align-v="center">
+        <b-col cols=11 sm=12>
+          <div>
+            <b-form-select
+              v-model="platformType"
+              v-on:input="$emit('input', $event)"
+              :options="this.platformTypes[this.flashCartType]"
+              :disabled="disabled"
+            />
+            <help-button
+              popover-text="Select the type of game that the save is for."
+              :id="`${this.id}-platform-type`"
+              class="help-button"
+            />
+          </div>
+        </b-col>
+      </b-row>
+    </div>
   </div>
 </template>
 
@@ -73,6 +75,7 @@ export default {
       if (this.flashCartType !== null) {
         if (this.platformTypes[this.flashCartType].length === 1) {
           this.platformType = this.platformTypes[this.flashCartType][0].value;
+          this.$emit('input', this.platformType); // The second dropdown is invisible, so no events will be emitted from it because nothing will be selected
         } else {
           this.platformType = null; // If > 1 item in the list, then display the "Choose game type" option
         }

--- a/frontend/src/components/FlashCartType.vue
+++ b/frontend/src/components/FlashCartType.vue
@@ -1,7 +1,10 @@
 <template>
     <div>
     <b-row no-gutters align-h="start" align-v="center">
-      <b-col cols=11 sm=12>
+      <b-col cols=4 class="text-left text-label">
+        Flash cart type:
+      </b-col>
+      <b-col cols=7 sm=8>
         <div>
           <b-form-select
             v-model="flashCartType"
@@ -18,7 +21,10 @@
       </b-col>
     </b-row>
     <b-row no-gutters align-h="start" align-v="center">
-      <b-col cols=11 sm=12>
+     <b-col cols=4 class="text-left text-label">
+        Game type:
+      </b-col>
+      <b-col cols=7 sm=8>
         <div>
           <b-form-select
             v-model="platformType"
@@ -42,6 +48,10 @@
     position: absolute;
     right: -1.2em;
     top: 0em;
+  }
+
+  .text-label {
+    padding-left: 0.75em;
   }
 </style>
 

--- a/frontend/src/components/FlashCartType.vue
+++ b/frontend/src/components/FlashCartType.vue
@@ -4,14 +4,31 @@
       <b-col cols=11 sm=12>
         <div>
           <b-form-select
-            v-bind:value="value"
-            v-on:input="$emit('input', $event)"
-            :options="options"
+            v-model="flashCartType"
+            v-on:input="changeFlashCartType()"
+            :options="flashCartTypes"
             :disabled="disabled"
           />
           <help-button
-            popover-text="Select the platform (Game Boy, Nintendo 64, etc.) that the save is for."
-            :id="this.id"
+            popover-text="Select the type of flash cart that you're using."
+            :id="`${this.id}-flash-cart-type`"
+            class="help-button"
+          />
+        </div>
+      </b-col>
+    </b-row>
+    <b-row no-gutters align-h="start" align-v="center">
+      <b-col cols=11 sm=12>
+        <div>
+          <b-form-select
+            v-model="platformType"
+            v-on:input="$emit('input', $event)"
+            :options="this.platformTypes[this.flashCartType]"
+            :disabled="disabled"
+          />
+          <help-button
+            popover-text="Select the type of game that the save is for."
+            :id="`${this.id}-platform-type`"
             class="help-button"
           />
         </div>
@@ -47,26 +64,66 @@ export default {
   components: {
     HelpButton,
   },
+  methods: {
+    changeFlashCartType() {
+      if (this.flashCartType !== null) {
+        if (this.platformTypes[this.flashCartType].length === 1) {
+          this.platformType = this.platformTypes[this.flashCartType][0].value;
+        } else {
+          this.platformType = null; // If > 1 item in the list, then display the "Choose game type" option
+        }
+      } else {
+        this.platformType = null;
+      }
+    },
+  },
   data() {
     return {
-      // Commented out ones are platforms we support elsewhere on the site but are currently available on the MiSTer
-
-      options: [
-        { value: null, text: 'Choose platform', disabled: true },
-        { value: 'FlashCart-NES', text: 'NES' },
-        { value: 'FlashCart-SNES', text: 'SNES' },
-        { value: 'FlashCart-GB', text: 'Gameboy/Gameboy Color' },
-        { value: 'FlashCart-GBA', text: 'Gameboy Advance' },
-        { value: 'FlashCart-GoombaEmulator', text: 'GB/GBC on GBA (Goomba emulator)' },
-        { value: 'FlashCart-PocketNesEmulator', text: 'NES on GBA (PocketNES emulator)' },
-        { value: 'FlashCart-SMSAdvanceEmulator', text: 'SMS on GBA (SMSAdvance emulator)' },
-        { value: 'FlashCart-GenesisEverdrive', text: 'Genesis (Everdrive)' },
-        { value: 'FlashCart-NESGenesisEverdrive', text: 'NES on Genesis (Everdrive)' },
-        { value: 'FlashCart-SMSGenesisEverdrive', text: 'SMS on Genesis (Everdrive)' },
-        { value: 'FlashCart-GenesisMegaSD', text: 'Genesis (Mega SD)' },
-        { value: 'FlashCart-SMSGenesisMegaSD', text: 'SMS on Genesis (Mega SD)' },
-        { value: 'FlashCart-N64', text: 'Nintendo 64' },
+      flashCartType: null,
+      platformType: null,
+      flashCartTypes: [
+        { value: null, text: 'Choose flash cart type', disabled: true },
+        { value: 'NES', text: 'NES' },
+        { value: 'SNES', text: 'SNES' },
+        { value: 'GB', text: 'Gameboy/Gameboy Color' },
+        { value: 'GBA', text: 'Gameboy Advance' },
+        { value: 'GenesisEverdrive', text: 'Genesis (Everdrive)' },
+        { value: 'GenesisMegaSD', text: 'Genesis (Mega SD)' },
+        { value: 'N64', text: 'Nintendo 64' },
       ],
+
+      platformTypes: {
+        NES: [
+          { value: 'FlashCart-NES', text: 'NES' },
+        ],
+        SNES: [
+          { value: 'FlashCart-SNES', text: 'SNES' },
+        ],
+        GB: [
+          { value: 'FlashCart-GB', text: 'Gameboy/Gameboy Color' },
+        ],
+        GBA: [
+          { value: null, text: 'Choose game type', disabled: true },
+          { value: 'FlashCart-GBA', text: 'Gameboy Advance' },
+          { value: 'FlashCart-GoombaEmulator', text: 'GB/GBC (Goomba emulator)' },
+          { value: 'FlashCart-PocketNesEmulator', text: 'NES (PocketNES emulator)' },
+          { value: 'FlashCart-SMSAdvanceEmulator', text: 'SMS (SMSAdvance emulator)' },
+        ],
+        GenesisEverdrive: [
+          { value: null, text: 'Choose game type', disabled: true },
+          { value: 'FlashCart-GenesisEverdrive', text: 'Genesis' },
+          { value: 'FlashCart-NESGenesisEverdrive', text: 'NES' },
+          { value: 'FlashCart-SMSGenesisEverdrive', text: 'SMS' },
+        ],
+        GenesisMegaSD: [
+          { value: null, text: 'Choose game type', disabled: true },
+          { value: 'FlashCart-GenesisMegaSD', text: 'Genesis' },
+          { value: 'FlashCart-SMSGenesisMegaSD', text: 'SMS' },
+        ],
+        N64: [
+          { value: 'FlashCart-N64', text: 'Nintendo 64' },
+        ],
+      },
     };
   },
 };

--- a/frontend/src/save-formats/FlashCarts/Genesis/MegaSD/Genesis.js
+++ b/frontend/src/save-formats/FlashCarts/Genesis/MegaSD/Genesis.js
@@ -142,7 +142,7 @@ export default class GenesisMegaSdGenesisFlashCartSaveData {
   }
 
   static adjustOutputSizesPlatform() {
-    return 'genesis';
+    return null; // We pad out our files, so this doesn't make much sense here
   }
 
   constructor(flashCartArrayBuffer, rawArrayBuffer) {


### PR DESCRIPTION
The single dropdown was getting cluttered, and there's more options that we need to add in the future. So here we split it into 2 dropdowns (first select the type of cart, then the type of save) for clarity and simplicity