### PR TITLE
Removed the link to using a Retron5 to erase a cartridge

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,8 +3,7 @@
     <div id="nav">
       <b-row>
         <b-col class="nav-row">
-          <router-link to="/retron-5">Retron{{'\xa0'}}5 / RetroFreak</router-link> |
-          <router-link to="/retron-5/erase-save">Erase{{'\xa0'}}save from cartridge</router-link>
+          <router-link to="/retron-5">Retron{{'\xa0'}}5 / RetroFreak</router-link>
         </b-col>
       </b-row>
       <b-row>


### PR DESCRIPTION
Usage data shows that almost no one uses this feature (a total of 4 users in a year, compared to 42 users in the same time period who used the non-Retron5 version).

The feature itself is left in if you follow a link from somewhere, but removed from the nav to help declutter.