### PR TITLE
Add a default filename when creating a memory card image from a series of files

### DIFF
--- a/frontend/src/components/ConvertN64DexDrive.vue
+++ b/frontend/src/components/ConvertN64DexDrive.vue
@@ -242,6 +242,12 @@ export default {
         }));
 
         this.dexDriveSaveData = N64DexDriveSaveData.createFromSaveFiles(saveFiles);
+
+        if (this.dexDriveSaveData.getSaveFiles().length > 0) {
+          this.outputFilename = `${Util.convertDescriptionToFilename(this.dexDriveSaveData.getSaveFiles()[0].noteName)}.n64`;
+        } else {
+          this.outputFilename = 'output.n64';
+        }
       } catch (e) {
         this.errorMessage = e.message;
         this.dexDriveSaveData = null;

--- a/frontend/src/components/ConvertN64Mempack.vue
+++ b/frontend/src/components/ConvertN64Mempack.vue
@@ -111,6 +111,7 @@
 
 <script>
 import { saveAs } from 'file-saver';
+import Util from '../util/util';
 import InputFile from './InputFile.vue';
 import OutputFilename from './OutputFilename.vue';
 import ConversionDirection from './ConversionDirection.vue';
@@ -195,6 +196,12 @@ export default {
         }));
 
         this.mempackSaveData = N64MempackSaveData.createFromSaveFiles(saveFiles);
+
+        if (this.mempackSaveData.getSaveFiles().length > 0) {
+          this.outputFilename = `${Util.convertDescriptionToFilename(this.mempackSaveData.getSaveFiles()[0].noteName)}.mpk`;
+        } else {
+          this.outputFilename = 'output.mpk';
+        }
       } catch (e) {
         this.errorMessage = e.message;
         this.mempackSaveData = null;

--- a/frontend/src/components/ConvertPs1DexDrive.vue
+++ b/frontend/src/components/ConvertPs1DexDrive.vue
@@ -234,6 +234,12 @@ export default {
         const saveFiles = event.map((f) => ({ filename: f.filename, rawData: f.arrayBuffer, comment: 'Created with savefileconverter.com' }));
 
         this.dexDriveSaveData = PS1DexDriveSaveData.createFromSaveFiles(saveFiles);
+
+        if (this.dexDriveSaveData.getSaveFiles().length > 0) {
+          this.outputFilename = `${Util.convertDescriptionToFilename(this.dexDriveSaveData.getSaveFiles()[0].description)}.gme`;
+        } else {
+          this.outputFilename = 'output.gme';
+        }
       } catch (e) {
         this.errorMessage = e.message;
         this.dexDriveSaveData = null;

--- a/frontend/src/components/ConvertPs1Emulator.vue
+++ b/frontend/src/components/ConvertPs1Emulator.vue
@@ -111,6 +111,7 @@
 
 <script>
 import { saveAs } from 'file-saver';
+import Util from '../util/util';
 import InputFile from './InputFile.vue';
 import OutputFilename from './OutputFilename.vue';
 import ConversionDirection from './ConversionDirection.vue';
@@ -184,6 +185,12 @@ export default {
         const saveFiles = event.map((f) => ({ filename: f.filename, rawData: f.arrayBuffer }));
 
         this.memcardSaveData = Ps1MemcardSaveData.createFromSaveFiles(saveFiles);
+
+        if (this.memcardSaveData.getSaveFiles().length > 0) {
+          this.outputFilename = `${Util.convertDescriptionToFilename(this.memcardSaveData.getSaveFiles()[0].description)}.mcr`;
+        } else {
+          this.outputFilename = 'output.mcr';
+        }
       } catch (e) {
         this.errorMessage = e.message;
         this.memcardSaveData = null;

--- a/frontend/src/util/util.js
+++ b/frontend/src/util/util.js
@@ -17,6 +17,22 @@ export default class Util {
     return `${Util.removeFilenameExtension(filename)}${stringToAppend}${path.extname(filename)}`;
   }
 
+  static convertDescriptionToFilename(description) {
+    // First, remove everything but A-Z, a-z, 0-9, dash, underscore, space
+    // Then check how many A-Z, a-z, 0-9 there are. If > 0 then done, if 0 then return 'output'
+    // This is to prevent a filename of just being a single space, or a dash, etc, if the
+    // original description is all japanese characters plus a space, for example
+
+    const descriptionStripped = description.replace(/[^0-9a-z_\- ]/gi, '');
+    const descriptionStrippedAlphanumeric = descriptionStripped.replace(/[^0-9a-z]/gi, '');
+
+    if (descriptionStrippedAlphanumeric.length > 0) {
+      return descriptionStripped;
+    }
+
+    return 'output';
+  }
+
   static bufferToArrayBuffer(b) {
     return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength); // https://stackoverflow.com/questions/8609289/convert-a-binary-nodejs-buffer-to-javascript-arraybuffer/31394257#31394257
   }

--- a/frontend/tests/unit/util/util.spec.js
+++ b/frontend/tests/unit/util/util.spec.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import Util from '@/util/util';
+
+describe('Util', () => {
+  it('should convert a description into a filename', () => {
+    // Some simple made-up strings
+    expect(Util.convertDescriptionToFilename('thunderforce 3')).to.equal('thunderforce 3');
+    expect(Util.convertDescriptionToFilename('Thunderforce 3')).to.equal('Thunderforce 3');
+    expect(Util.convertDescriptionToFilename('THUNDERFORCE 3')).to.equal('THUNDERFORCE 3');
+    expect(Util.convertDescriptionToFilename('Thunderforce 3!')).to.equal('Thunderforce 3');
+    expect(Util.convertDescriptionToFilename('***Thunderforce*** 3!')).to.equal('Thunderforce 3');
+
+    // Real descriptions from our test files, which contain special characters
+    expect(Util.convertDescriptionToFilename('T2-WAREHOUSE.P')).to.equal('T2-WAREHOUSEP');
+    expect(Util.convertDescriptionToFilename('T2-\'.G')).to.equal('T2-G');
+    expect(Util.convertDescriptionToFilename('BK6.SRAM')).to.equal('BK6SRAM');
+    expect(Util.convertDescriptionToFilename('A BUG\'S LIFE')).to.equal('A BUGS LIFE');
+    expect(Util.convertDescriptionToFilename('CASTLEVANIA-2 PHOENIX 208%')).to.equal('CASTLEVANIA-2 PHOENIX 208');
+    expect(Util.convertDescriptionToFilename('THPS4 CAREERー PHELIPE E RENATO')).to.equal('THPS4 CAREER PHELIPE E RENATO');
+    expect(Util.convertDescriptionToFilename('SUIKODEN2-(1) LV57  31:11:33')).to.equal('SUIKODEN2-1 LV57  311133');
+
+    // If the file is all special characters + whitespace then just return 'output'
+    expect(Util.convertDescriptionToFilename('!@#$ %^&* ()')).to.equal('output');
+  });
+});


### PR DESCRIPTION
This applies to:
- PS1 dexdrive
- PS1 emulator
- N64 dexdrive
- N64 emulator

We make up the filename by taking the first save in the newly-created memory card image and stripping out non-alphanumeric characters (but leaving spaces, hyphens, and underscores). If nothing but whitespace is left then we make it be `output`

Fixes https://github.com/euan-forrester/save-file-converter/issues/170