### PR TITLE
Display region information for saves that contain it

### DIFF
--- a/frontend/src/components/ConvertN64DexDrive.vue
+++ b/frontend/src/components/ConvertN64DexDrive.vue
@@ -177,7 +177,7 @@ export default {
     },
     getFileListNames() {
       if ((this.dexDriveSaveData !== null) && (this.dexDriveSaveData.getSaveFiles() !== null)) {
-        return this.dexDriveSaveData.getSaveFiles().map((x) => ({ displayText: N64MempackSaveData.isCartSave(x) ? `Cartridge save: ${x.noteName}` : x.noteName }));
+        return this.dexDriveSaveData.getSaveFiles().map((x) => ({ displayText: N64MempackSaveData.isCartSave(x) ? `Cartridge save: ${x.noteName}` : `${x.noteName} (${x.regionName})` }));
       }
 
       return [];

--- a/frontend/src/components/ConvertN64Mempack.vue
+++ b/frontend/src/components/ConvertN64Mempack.vue
@@ -146,7 +146,7 @@ export default {
   methods: {
     getFileListNames() {
       if ((this.mempackSaveData !== null) && (this.mempackSaveData.getSaveFiles() !== null)) {
-        return this.mempackSaveData.getSaveFiles().map((x) => ({ displayText: N64MempackSaveData.isCartSave(x) ? `Cartridge save: ${x.noteName}` : x.noteName }));
+        return this.mempackSaveData.getSaveFiles().map((x) => ({ displayText: N64MempackSaveData.isCartSave(x) ? `Cartridge save: ${x.noteName}` : `${x.noteName} (${x.regionName})` }));
       }
 
       return [];

--- a/frontend/src/components/ConvertPs1DexDrive.vue
+++ b/frontend/src/components/ConvertPs1DexDrive.vue
@@ -183,7 +183,7 @@ export default {
     },
     getFileListNames() {
       if ((this.dexDriveSaveData !== null) && (this.dexDriveSaveData.getSaveFiles() !== null)) {
-        return this.dexDriveSaveData.getSaveFiles().map((x) => ({ displayText: x.description }));
+        return this.dexDriveSaveData.getSaveFiles().map((x) => ({ displayText: `${x.description} (${x.regionName})` }));
       }
 
       return [];

--- a/frontend/src/components/ConvertPs1Emulator.vue
+++ b/frontend/src/components/ConvertPs1Emulator.vue
@@ -145,7 +145,7 @@ export default {
   methods: {
     getFileListNames() {
       if ((this.memcardSaveData !== null) && (this.memcardSaveData.getSaveFiles() !== null)) {
-        return this.memcardSaveData.getSaveFiles().map((x) => ({ displayText: x.description }));
+        return this.memcardSaveData.getSaveFiles().map((x) => ({ displayText: `${x.description} (${x.regionName})` }));
       }
 
       return [];

--- a/frontend/src/components/ConvertPs1Ps3.vue
+++ b/frontend/src/components/ConvertPs1Ps3.vue
@@ -189,7 +189,7 @@ export default {
     },
     getFileListNames() {
       if ((this.ps3SaveData !== null) && (this.ps3SaveData.getSaveFiles() !== null)) {
-        return this.ps3SaveData.getSaveFiles().map((x) => ({ displayText: x.description }));
+        return this.ps3SaveData.getSaveFiles().map((x) => ({ displayText: `${x.description} (${x.regionName})` }));
       }
 
       return [];

--- a/frontend/src/components/ConvertPs1Psp.vue
+++ b/frontend/src/components/ConvertPs1Psp.vue
@@ -188,7 +188,7 @@ export default {
     },
     getFileListNames() {
       if ((this.pspSaveData !== null) && (this.pspSaveData.getSaveFiles() !== null)) {
-        return this.pspSaveData.getSaveFiles().map((x) => ({ displayText: x.description }));
+        return this.pspSaveData.getSaveFiles().map((x) => ({ displayText: `${x.description} (${x.regionName})` }));
       }
 
       return [];

--- a/frontend/src/components/ConvertWii.vue
+++ b/frontend/src/components/ConvertWii.vue
@@ -25,6 +25,9 @@
               :errorMessage="this.platformErrorMessage"
               :disabled="this.currentlyLoadingPlatform"
             />
+            <region-viewer
+              :regionName="this.regionName"
+            />
           </div>
           <div v-else>
             <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
@@ -129,6 +132,7 @@ import InputFile from './InputFile.vue';
 import OutputFilename from './OutputFilename.vue';
 import ConversionDirection from './ConversionDirection.vue';
 import WiiVcPlatform from './WiiVcPlatform.vue';
+import RegionViewer from './RegionViewer.vue';
 import WiiSaveData from '../save-formats/Wii/Wii';
 import GetPlatform from '../save-formats/Wii/GetPlatform';
 import ConvertFromPlatform from '../save-formats/Wii/ConvertFromPlatform';
@@ -143,6 +147,7 @@ export default {
       outputSaveData: null,
       errorMessage: null,
       platformErrorMessage: null,
+      regionName: null,
       outputFilename: null,
       outputPlatform: null,
       currentlyLoadingPlatform: null,
@@ -154,6 +159,7 @@ export default {
     ConversionDirection,
     InputFile,
     OutputFilename,
+    RegionViewer,
     WiiVcPlatform,
   },
   methods: {
@@ -162,6 +168,7 @@ export default {
       this.outputSaveData = null;
       this.errorMessage = null;
       this.platformErrorMessage = null;
+      this.regionName = null;
       this.outputFilename = null;
       this.outputPlatform = null;
       this.currentlyLoadingPlatform = false;
@@ -173,6 +180,7 @@ export default {
       this.outputFilename = null;
       this.outputSaveData = null;
       this.outputPlatform = null;
+      this.regionName = null;
       this.currentlyLoadingPlatform = false;
       this.wiiSaveData = null;
       this.inputFilename = null;
@@ -186,11 +194,13 @@ export default {
         this.inputFilename = event.filename;
 
         this.currentlyLoadingPlatform = true;
-        const platform = await getPlatform.get(this.wiiSaveData.getGameId());
+        const gameInfo = await getPlatform.get(this.wiiSaveData.getGameId());
         this.currentlyLoadingPlatform = false;
 
-        if (platform !== GetPlatform.unknownPlatform()) {
-          this.outputPlatform = platform; // Triggers outputPlatformChanged()
+        this.regionName = gameInfo.region;
+
+        if (gameInfo.platform !== GetPlatform.unknownPlatform()) {
+          this.outputPlatform = gameInfo.platform; // Triggers outputPlatformChanged()
         } else {
           this.platformErrorMessage = 'Unable to automatically determine the platform for this save. Please select it manually.';
         }

--- a/frontend/src/components/RegionViewer.vue
+++ b/frontend/src/components/RegionViewer.vue
@@ -1,0 +1,30 @@
+<template>
+  <b-collapse appear id="id" :visible="this.regionName !== null">
+  <b-list-group>
+    <b-list-group-item class="d-flex justify-content-between align-items-center align-padding">
+      <div>Region:</div><div>{{ regionName }}</div>
+    </b-list-group-item>
+  </b-list-group>
+  </b-collapse>
+</template>
+
+<style scoped>
+  /* Align the word "Region" with the text in the dropdown above */
+  .align-padding {
+    padding-left: 0.7em;
+    padding-right: 0.7em;
+  }
+</style>
+
+<script>
+
+export default {
+  name: 'RegionViewer',
+  props: {
+    regionName: {
+      type: String,
+      default: null,
+    },
+  },
+};
+</script>

--- a/frontend/src/save-formats/N64/Mempack.js
+++ b/frontend/src/save-formats/N64/Mempack.js
@@ -78,6 +78,28 @@ const CART_SAVE_SIZES = [
   2048,
 ];
 
+// Taken from https://github.com/bryc/mempak/blob/master/js/codedb.js#L88
+const REGION_CODE_TO_NAME = {
+  A: 'All regions',
+  B: 'Brazil', // Unlicensed?
+  C: 'China', // Unused?
+  D: 'Germany',
+  E: 'North America',
+  F: 'France',
+  H: 'Netherlands', // Unused. GC/Wii only.
+  I: 'Italy',
+  J: 'Japan',
+  K: 'South Korea', // Unused. GC/Wii only.
+  P: 'Europe',
+  R: 'Russia', // Unused. Wii only.
+  S: 'Spain',
+  U: 'Australia', // Although some AU games used standard P codes.
+  W: 'Taiwan', // Unused. GC/Wii only.
+  X: 'Europe', // Alternative PAL version (Other languages)
+  Y: 'Europe', // Alternative PAL version (Other languages)
+  Z: 'Europe', // Unused. Alternative PAL version 3. Possibly Wii only.
+};
+
 const GAMESHARK_ACTIONREPLAY_CART_SAVE_GAME_SERIAL_CODE = '\x3B\xAD\xD1\xE5';
 const GAMESHARK_ACTIONREPLAY_CART_SAVE_PUBLISHER_CODE = '\xFA\xDE';
 const BLACKBAG_CART_SAVE_GAME_SERIAL_CODE = '\xDE\xAD\xBE\xEF'; // #cute
@@ -284,6 +306,16 @@ function getMediaCode(gameSerialCode) {
   return gameSerialCode.charAt(GAME_SERIAL_CODE_MEDIA_INDEX);
 }
 
+function getRegionName(gameSerialCode) {
+  const regionCode = getRegionCode(gameSerialCode);
+
+  if (regionCode in REGION_CODE_TO_NAME) {
+    return REGION_CODE_TO_NAME[regionCode];
+  }
+
+  return 'Unknown region';
+}
+
 // Taken from https://github.com/bryc/mempak/blob/master/js/parser.js#L173
 function readNoteTable(inodePageArrayBuffer, noteTableArrayBuffer) {
   const noteKeys = [];
@@ -343,6 +375,7 @@ function readNoteTable(inodePageArrayBuffer, noteTableArrayBuffer) {
         publisherCodeFixup,
         noteName,
         region: getRegionCode(gameSerialCode),
+        regionName: getRegionName(gameSerialCode),
         media: getMediaCode(gameSerialCode),
       });
     }

--- a/frontend/src/save-formats/PS1/Memcard.js
+++ b/frontend/src/save-formats/PS1/Memcard.js
@@ -42,6 +42,30 @@ const SAVE_BLOCK_DESCRIPTION_OFFSET = 0x04;
 const SAVE_BLOCK_DESCRIPTION_LENGTH = 64;
 const SAVE_BLOCK_DESCRIPTION_ENCODING = 'shift-jis';
 
+// The filename begins with the country code:
+// https://www.psdevwiki.com/ps3/PS1_Savedata#Virtual_Memory_Card_PS1_.28.VM1.29
+function getRegionName(filename) {
+  const firstChar = filename.charAt(0);
+
+  if (firstChar === 'B') {
+    const secondChar = filename.charAt(1);
+
+    if (secondChar === 'I') {
+      return 'Japan';
+    }
+
+    if (secondChar === 'A') {
+      return 'North America';
+    }
+
+    if (secondChar === 'E') {
+      return 'Europe';
+    }
+  }
+
+  return 'Unknown region';
+}
+
 function convertTextToHalfWidth(s) {
   // The description stored in the save data is in full-width characters but we'd rather display normal half-width ones
   // https://stackoverflow.com/a/58515363
@@ -328,6 +352,7 @@ export default class Ps1MemcardSaveData {
         // This block begins a save, which may be comprised of several blocks
 
         const filename = Util.trimNull(filenameTextDecoder.decode(directoryFrame.slice(DIRECTORY_FRAME_FILENAME_OFFSET, DIRECTORY_FRAME_FILENAME_OFFSET + DIRECTORY_FRAME_FILENAME_LENGTH)));
+        const regionName = getRegionName(filename);
         const expectedSize = directoryFrameDataView.getUint32(DIRECTORY_FRAME_FILE_SIZE_OFFSET, LITTLE_ENDIAN);
         const dataBlocks = [getBlock(dataBlocksArrayBuffer, i)];
 
@@ -365,6 +390,7 @@ export default class Ps1MemcardSaveData {
         this.saveFiles.push({
           startingBlock: i,
           filename,
+          regionName,
           description,
           rawData,
         });

--- a/frontend/tests/unit/save-formats/N64/DexDrive.spec.js
+++ b/frontend/tests/unit/save-formats/N64/DexDrive.spec.js
@@ -87,6 +87,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal('NKTJ');
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal('01');
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal('J');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('Japan');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNoteArrayBuffer)).to.equal(true);
   });
@@ -109,6 +110,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal('NPDE');
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal('4Y');
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal('E');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNoteArrayBuffer)).to.equal(true);
 
@@ -134,6 +136,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal('NTQE');
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal('52');
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal('E');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNote1ArrayBuffer)).to.equal(true);
 
@@ -144,6 +147,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[1].gameSerialCode).to.equal('NTQE');
     expect(dexDriveSaveData.getSaveFiles()[1].publisherCode).to.equal('52');
     expect(dexDriveSaveData.getSaveFiles()[1].region).to.equal('E');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[1].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[1].rawData, rawNote2ArrayBuffer)).to.equal(true);
   });
@@ -181,6 +185,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal('NTQE');
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal('52');
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal('E');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNote1ArrayBuffer)).to.equal(true);
 
@@ -191,6 +196,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[1].gameSerialCode).to.equal('NTQE');
     expect(dexDriveSaveData.getSaveFiles()[1].publisherCode).to.equal('52');
     expect(dexDriveSaveData.getSaveFiles()[1].region).to.equal('E');
+    expect(dexDriveSaveData.getSaveFiles()[1].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[1].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[1].rawData, rawNote2ArrayBuffer)).to.equal(true);
   });
@@ -213,6 +219,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_GAME_SERIAL_CODE);
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_PUBLISHER_CODE);
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_REGION_CODE);
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('Unknown region');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_MEDIA_CODE);
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNoteArrayBuffer)).to.equal(true);
   });
@@ -236,6 +243,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal(N64MempackSaveData.BLACKBAG_CART_SAVE_GAME_SERIAL_CODE);
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal(N64MempackSaveData.BLACKBAG_CART_SAVE_PUBLISHER_CODE);
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal(N64MempackSaveData.BLACKBAG_CART_SAVE_REGION_CODE);
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('Unknown region');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal(N64MempackSaveData.BLACKBAG_CART_SAVE_MEDIA_CODE);
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNote1ArrayBuffer)).to.equal(true);
 
@@ -246,6 +254,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[1].gameSerialCode).to.equal(N64MempackSaveData.BLACKBAG_CART_SAVE_GAME_SERIAL_CODE);
     expect(dexDriveSaveData.getSaveFiles()[1].publisherCode).to.equal(N64MempackSaveData.BLACKBAG_CART_SAVE_PUBLISHER_CODE);
     expect(dexDriveSaveData.getSaveFiles()[1].region).to.equal(N64MempackSaveData.BLACKBAG_CART_SAVE_REGION_CODE);
+    expect(dexDriveSaveData.getSaveFiles()[1].regionName).to.equal('Unknown region');
     expect(dexDriveSaveData.getSaveFiles()[1].media).to.equal(N64MempackSaveData.BLACKBAG_CART_SAVE_MEDIA_CODE);
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[1].rawData, rawNote2ArrayBuffer)).to.equal(true);
   });
@@ -270,6 +279,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_GAME_SERIAL_CODE);
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_PUBLISHER_CODE);
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_REGION_CODE);
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('Unknown region');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_MEDIA_CODE);
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNoteArrayBuffer)).to.equal(true);
   });
@@ -297,6 +307,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal('NAME');
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal('5H');
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal('E');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNote1ArrayBuffer)).to.equal(true);
 
@@ -307,6 +318,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[1].gameSerialCode).to.equal('NBYE');
     expect(dexDriveSaveData.getSaveFiles()[1].publisherCode).to.equal('52');
     expect(dexDriveSaveData.getSaveFiles()[1].region).to.equal('E');
+    expect(dexDriveSaveData.getSaveFiles()[1].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[1].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[1].rawData, rawNote2ArrayBuffer)).to.equal(true);
 
@@ -317,6 +329,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[2].gameSerialCode).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_GAME_SERIAL_CODE);
     expect(dexDriveSaveData.getSaveFiles()[2].publisherCode).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_PUBLISHER_CODE);
     expect(dexDriveSaveData.getSaveFiles()[2].region).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_REGION_CODE);
+    expect(dexDriveSaveData.getSaveFiles()[2].regionName).to.equal('Unknown region');
     expect(dexDriveSaveData.getSaveFiles()[2].media).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_MEDIA_CODE);
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[2].rawData, rawNote3ArrayBuffer)).to.equal(true);
 
@@ -327,6 +340,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[3].gameSerialCode).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_GAME_SERIAL_CODE);
     expect(dexDriveSaveData.getSaveFiles()[3].publisherCode).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_PUBLISHER_CODE);
     expect(dexDriveSaveData.getSaveFiles()[3].region).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_REGION_CODE);
+    expect(dexDriveSaveData.getSaveFiles()[3].regionName).to.equal('Unknown region');
     expect(dexDriveSaveData.getSaveFiles()[3].media).to.equal(N64MempackSaveData.GAMESHARK_ACTIONREPLAY_CART_SAVE_MEDIA_CODE);
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[3].rawData, rawNote4ArrayBuffer)).to.equal(true);
   });
@@ -349,6 +363,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal('NWIE');
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal('51');
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal('E');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNoteArrayBuffer)).to.equal(true);
   });
@@ -371,6 +386,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal('NWIE');
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal('51');
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal('E');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNoteArrayBuffer)).to.equal(true);
   });
@@ -393,6 +409,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal('NWIE');
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal('51');
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal('E');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNoteArrayBuffer)).to.equal(true);
   });
@@ -416,6 +433,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].gameSerialCode).to.equal('NRDP');
     expect(dexDriveSaveData.getSaveFiles()[0].publisherCode).to.equal('5D');
     expect(dexDriveSaveData.getSaveFiles()[0].region).to.equal('P');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('Europe');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNote1ArrayBuffer)).to.equal(true);
 
@@ -426,6 +444,7 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[1].gameSerialCode).to.equal('NRDP');
     expect(dexDriveSaveData.getSaveFiles()[1].publisherCode).to.equal('5D');
     expect(dexDriveSaveData.getSaveFiles()[1].region).to.equal('P');
+    expect(dexDriveSaveData.getSaveFiles()[1].regionName).to.equal('Europe');
     expect(dexDriveSaveData.getSaveFiles()[1].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[1].rawData, rawNote2ArrayBuffer)).to.equal(true);
   });

--- a/frontend/tests/unit/save-formats/N64/Mempack.spec.js
+++ b/frontend/tests/unit/save-formats/N64/Mempack.spec.js
@@ -46,6 +46,7 @@ describe('N64 - Mempack save format', () => {
     expect(mempackSaveData.getSaveFiles()[0].gameSerialCode).to.equal('NKTJ');
     expect(mempackSaveData.getSaveFiles()[0].publisherCode).to.equal('01');
     expect(mempackSaveData.getSaveFiles()[0].region).to.equal('J');
+    expect(mempackSaveData.getSaveFiles()[0].regionName).to.equal('Japan');
     expect(mempackSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(mempackSaveData.getSaveFiles()[0].rawData, rawNoteArrayBuffer)).to.equal(true);
   });
@@ -80,6 +81,7 @@ describe('N64 - Mempack save format', () => {
     expect(mempackSaveData.getSaveFiles()[0].gameSerialCode).to.equal('NTQE');
     expect(mempackSaveData.getSaveFiles()[0].publisherCode).to.equal('52');
     expect(mempackSaveData.getSaveFiles()[0].region).to.equal('E');
+    expect(mempackSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(mempackSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(mempackSaveData.getSaveFiles()[0].rawData, rawNote1ArrayBuffer)).to.equal(true);
 
@@ -89,6 +91,7 @@ describe('N64 - Mempack save format', () => {
     expect(mempackSaveData.getSaveFiles()[1].gameSerialCode).to.equal('NTQE');
     expect(mempackSaveData.getSaveFiles()[1].publisherCode).to.equal('52');
     expect(mempackSaveData.getSaveFiles()[1].region).to.equal('E');
+    expect(mempackSaveData.getSaveFiles()[1].regionName).to.equal('North America');
     expect(mempackSaveData.getSaveFiles()[1].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(mempackSaveData.getSaveFiles()[1].rawData, rawNote2ArrayBuffer)).to.equal(true);
   });

--- a/frontend/tests/unit/save-formats/PS1/DexDrive.spec.js
+++ b/frontend/tests/unit/save-formats/PS1/DexDrive.spec.js
@@ -49,6 +49,7 @@ describe('PS1 - DexDrive save format', () => {
 
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-00067DRAX01');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal('');
     expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('CASTLEVANIA-2 PHOENIX 208%');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawArrayBuffer)).to.equal(true);
@@ -64,12 +65,14 @@ describe('PS1 - DexDrive save format', () => {
 
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-00067DRAX00');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal('');
     expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('CASTLEVANIA-1 ALUCARD 200%');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawArrayBuffers[0])).to.equal(true);
 
     expect(dexDriveSaveData.getSaveFiles()[1].startingBlock).to.equal(1);
     expect(dexDriveSaveData.getSaveFiles()[1].filename).to.equal('BASLUS-00067DRAX01');
+    expect(dexDriveSaveData.getSaveFiles()[1].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[1].comment).to.equal('');
     expect(dexDriveSaveData.getSaveFiles()[1].description).to.equal('CASTLEVANIA-2 RICHTER 195%');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[1].rawData, rawArrayBuffers[1])).to.equal(true);
@@ -85,6 +88,7 @@ describe('PS1 - DexDrive save format', () => {
 
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASCUS-94194GT');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal('');
     expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('GT game data');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawArrayBuffer)).to.equal(true);
@@ -100,12 +104,14 @@ describe('PS1 - DexDrive save format', () => {
 
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(6);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASCUS-94194GT');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal('');
     expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('GT game data');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawArrayBuffers[0])).to.equal(true);
 
     expect(dexDriveSaveData.getSaveFiles()[1].startingBlock).to.equal(12);
     expect(dexDriveSaveData.getSaveFiles()[1].filename).to.equal('BASCUS-94194RT');
+    expect(dexDriveSaveData.getSaveFiles()[1].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[1].comment).to.equal('');
     expect(dexDriveSaveData.getSaveFiles()[1].description).to.equal('GT replay data');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[1].rawData, rawArrayBuffers[1])).to.equal(true);
@@ -123,12 +129,14 @@ describe('PS1 - DexDrive save format', () => {
 
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASCUS-94194GT');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal(COMMENTS[0]);
     expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('GT game data');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, saveFilesArrayBuffers[0])).to.equal(true);
 
     expect(dexDriveSaveData.getSaveFiles()[1].startingBlock).to.equal(5);
     expect(dexDriveSaveData.getSaveFiles()[1].filename).to.equal('BASCUS-94194RT');
+    expect(dexDriveSaveData.getSaveFiles()[1].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[1].comment).to.equal(COMMENTS[1]);
     expect(dexDriveSaveData.getSaveFiles()[1].description).to.equal('GT replay data');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[1].rawData, saveFilesArrayBuffers[1])).to.equal(true);
@@ -146,6 +154,7 @@ describe('PS1 - DexDrive save format', () => {
 
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-01032DMR0');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal('');
     expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('Digi 1onFou');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawArrayBuffer)).to.equal(true);
@@ -161,6 +170,7 @@ describe('PS1 - DexDrive save format', () => {
 
     expect(dexDriveSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(dexDriveSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-01485PNMOG01');
+    expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].comment).to.equal('');
     expect(dexDriveSaveData.getSaveFiles()[0].description).to.equal('THPS4 CAREERー PHELIPE E RENATO');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawArrayBuffer)).to.equal(true);

--- a/frontend/tests/unit/save-formats/PS1/Memcard.spec.js
+++ b/frontend/tests/unit/save-formats/PS1/Memcard.spec.js
@@ -25,11 +25,13 @@ describe('PS1 memcard save format', () => {
 
     expect(ps1MemcardSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(ps1MemcardSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-00067DRAX00');
+    expect(ps1MemcardSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(ps1MemcardSaveData.getSaveFiles()[0].description).to.equal('CASTLEVANIA-1 ALUCARD 200%');
     expect(ArrayBufferUtil.arrayBuffersEqual(ps1MemcardSaveData.getSaveFiles()[0].rawData, saveFilesArrayBuffers[0])).to.equal(true);
 
     expect(ps1MemcardSaveData.getSaveFiles()[1].startingBlock).to.equal(1);
     expect(ps1MemcardSaveData.getSaveFiles()[1].filename).to.equal('BASLUS-00067DRAX01');
+    expect(ps1MemcardSaveData.getSaveFiles()[1].regionName).to.equal('North America');
     expect(ps1MemcardSaveData.getSaveFiles()[1].description).to.equal('CASTLEVANIA-2 RICHTER 195%');
     expect(ArrayBufferUtil.arrayBuffersEqual(ps1MemcardSaveData.getSaveFiles()[1].rawData, saveFilesArrayBuffers[1])).to.equal(true);
   });
@@ -45,11 +47,13 @@ describe('PS1 memcard save format', () => {
 
     expect(ps1MemcardSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(ps1MemcardSaveData.getSaveFiles()[0].filename).to.equal('BASCUS-94194GT');
+    expect(ps1MemcardSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(ps1MemcardSaveData.getSaveFiles()[0].description).to.equal('GT game data');
     expect(ArrayBufferUtil.arrayBuffersEqual(ps1MemcardSaveData.getSaveFiles()[0].rawData, saveFilesArrayBuffers[0])).to.equal(true);
 
     expect(ps1MemcardSaveData.getSaveFiles()[1].startingBlock).to.equal(5);
     expect(ps1MemcardSaveData.getSaveFiles()[1].filename).to.equal('BASCUS-94194RT');
+    expect(ps1MemcardSaveData.getSaveFiles()[1].regionName).to.equal('North America');
     expect(ps1MemcardSaveData.getSaveFiles()[1].description).to.equal('GT replay data');
     expect(ArrayBufferUtil.arrayBuffersEqual(ps1MemcardSaveData.getSaveFiles()[1].rawData, saveFilesArrayBuffers[1])).to.equal(true);
   });
@@ -72,6 +76,7 @@ describe('PS1 memcard save format', () => {
 
     expect(ps1MemcardSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(ps1MemcardSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-00067DRAX00');
+    expect(ps1MemcardSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(ps1MemcardSaveData.getSaveFiles()[0].description).to.equal('CASTLEVANIA-1 EUAN 2%');
     expect(ArrayBufferUtil.arrayBuffersEqual(ps1MemcardSaveData.getSaveFiles()[0].rawData, rawArrayBuffer)).to.equal(true);
   });

--- a/frontend/tests/unit/save-formats/PS1/Psp.spec.js
+++ b/frontend/tests/unit/save-formats/PS1/Psp.spec.js
@@ -62,36 +62,43 @@ describe('PS1 - PSP save format', () => {
 
     expect(pspSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(pspSaveData.getSaveFiles()[0].filename).to.equal('BASLUS-00958GS2-1');
+    expect(pspSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(pspSaveData.getSaveFiles()[0].description).to.equal('SUIKODEN2-(1) LV57  31:11:33');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[0].rawData, rawArrayBuffers[0])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[1].startingBlock).to.equal(2);
     expect(pspSaveData.getSaveFiles()[1].filename).to.equal('BASLUS-00958GS2-2');
+    expect(pspSaveData.getSaveFiles()[1].regionName).to.equal('North America');
     expect(pspSaveData.getSaveFiles()[1].description).to.equal('SUIKODEN2-(2) LV57  31:16:35');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[1].rawData, rawArrayBuffers[1])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[2].startingBlock).to.equal(4);
     expect(pspSaveData.getSaveFiles()[2].filename).to.equal('BASLUS-00958GS2-3');
+    expect(pspSaveData.getSaveFiles()[2].regionName).to.equal('North America');
     expect(pspSaveData.getSaveFiles()[2].description).to.equal('SUIKODEN2-(3) LV57  31:25:14');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[2].rawData, rawArrayBuffers[2])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[3].startingBlock).to.equal(6);
     expect(pspSaveData.getSaveFiles()[3].filename).to.equal('BASLUS-00958GS2-4');
+    expect(pspSaveData.getSaveFiles()[3].regionName).to.equal('North America');
     expect(pspSaveData.getSaveFiles()[3].description).to.equal('SUIKODEN2-(4) LV54  30:31:12');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[3].rawData, rawArrayBuffers[3])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[4].startingBlock).to.equal(8);
     expect(pspSaveData.getSaveFiles()[4].filename).to.equal('BASLUS-00958GS2-5');
+    expect(pspSaveData.getSaveFiles()[4].regionName).to.equal('North America');
     expect(pspSaveData.getSaveFiles()[4].description).to.equal('SUIKODEN2-(5) LV59  32:30:22');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[4].rawData, rawArrayBuffers[4])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[5].startingBlock).to.equal(10);
     expect(pspSaveData.getSaveFiles()[5].filename).to.equal('BASLUS-00958GS2-6');
+    expect(pspSaveData.getSaveFiles()[5].regionName).to.equal('North America');
     expect(pspSaveData.getSaveFiles()[5].description).to.equal('SUIKODEN2-(6) LV60  32:39:39');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[5].rawData, rawArrayBuffers[5])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[6].startingBlock).to.equal(12);
     expect(pspSaveData.getSaveFiles()[6].filename).to.equal('BASLUS-00958GS2-7');
+    expect(pspSaveData.getSaveFiles()[6].regionName).to.equal('North America');
     expect(pspSaveData.getSaveFiles()[6].description).to.equal('SUIKODEN2-(7) LV60  32:54:42');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[6].rawData, rawArrayBuffers[6])).to.equal(true);
   });
@@ -108,11 +115,13 @@ describe('PS1 - PSP save format', () => {
 
     expect(pspSaveData.getSaveFiles()[0].startingBlock).to.equal(0);
     expect(pspSaveData.getSaveFiles()[0].filename).to.equal('BASCUS-94194GT');
+    expect(pspSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(pspSaveData.getSaveFiles()[0].description).to.equal('GT game data');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[0].rawData, saveFilesArrayBuffers[0])).to.equal(true);
 
     expect(pspSaveData.getSaveFiles()[1].startingBlock).to.equal(5);
     expect(pspSaveData.getSaveFiles()[1].filename).to.equal('BASCUS-94194RT');
+    expect(pspSaveData.getSaveFiles()[1].regionName).to.equal('North America');
     expect(pspSaveData.getSaveFiles()[1].description).to.equal('GT replay data');
     expect(ArrayBufferUtil.arrayBuffersEqual(pspSaveData.getSaveFiles()[1].rawData, saveFilesArrayBuffers[1])).to.equal(true);
 

--- a/frontend/tests/unit/save-formats/Wii/GetPlatform.spec.js
+++ b/frontend/tests/unit/save-formats/Wii/GetPlatform.spec.js
@@ -18,74 +18,88 @@ describe('Get Wii platform', function () { // eslint-disable-line func-names
   });
 
   it('should get the correct VC platform for an NES game', async () => {
-    const platform = await this.getPlatform.get('FBNE'); // Ninja Gaiden
-    expect(platform).equals('VC-NES');
+    const gameInfo = await this.getPlatform.get('FBNE'); // Ninja Gaiden
+    expect(gameInfo.platform).equals('VC-NES');
+    expect(gameInfo.region).equals('North America');
   });
 
   it('should get the correct VC platform for a SNES game', async () => {
-    const platform = await this.getPlatform.get('JECE'); // Chrono Trigger
-    expect(platform).equals('VC-SNES');
+    const gameInfo = await this.getPlatform.get('JECE'); // Chrono Trigger
+    expect(gameInfo.platform).equals('VC-SNES');
+    expect(gameInfo.region).equals('North America');
   });
 
   it('should get the correct VC platform for an N64 game', async () => {
-    const platform = await this.getPlatform.get('NADJ'); // Star Fox 64
-    expect(platform).equals('VC-N64');
+    const gameInfo = await this.getPlatform.get('NADJ'); // Star Fox 64
+    expect(gameInfo.platform).equals('VC-N64');
+    expect(gameInfo.region).equals('Japan');
   });
 
   it('should get the correct VC platform for a Turbografx 16 game', async () => {
-    const platform = await this.getPlatform.get('QAPN'); // Castlevania: Rondo of Blood
-    expect(platform).equals('VC-PCE');
+    const gameInfo = await this.getPlatform.get('QAPN'); // Castlevania: Rondo of Blood
+    expect(gameInfo.platform).equals('VC-PCE');
+    expect(gameInfo.region).equals('North America');
   });
 
   it('should get the correct VC platform for a Master System game', async () => {
-    const platform = await this.getPlatform.get('LADE'); // Phantasy Star
-    expect(platform).equals('VC-SMS');
+    const gameInfo = await this.getPlatform.get('LADE'); // Phantasy Star
+    expect(gameInfo.platform).equals('VC-SMS');
+    expect(gameInfo.region).equals('North America');
   });
 
   it('should get the correct VC platform for a Genesis game', async () => {
-    const platform = await this.getPlatform.get('MC4E'); // Strider
-    expect(platform).equals('VC-MD');
+    const gameInfo = await this.getPlatform.get('MC4E'); // Strider
+    expect(gameInfo.platform).equals('VC-MD');
+    expect(gameInfo.region).equals('North America');
   });
 
   it('should get the correct VC platform for a Neo Geo game', async () => {
-    const platform = await this.getPlatform.get('EAEP'); // Samurai Shodown
-    expect(platform).equals('VC-NEOGEO');
+    const gameInfo = await this.getPlatform.get('EAEP'); // Samurai Shodown
+    expect(gameInfo.platform).equals('VC-NEOGEO');
+    expect(gameInfo.region).equals('Europe');
   });
 
   it('should get the correct VC platform for a C64 game', async () => {
-    const platform = await this.getPlatform.get('C97E'); // California Games
-    expect(platform).equals('VC-C64');
+    const gameInfo = await this.getPlatform.get('C97E'); // California Games
+    expect(gameInfo.platform).equals('VC-C64');
+    expect(gameInfo.region).equals('North America');
   });
 
   it('should get the correct VC platform for an arcade game', async () => {
-    const platform = await this.getPlatform.get('E6ZJ'); // Star Force
-    expect(platform).equals('VC-Arcade');
+    const gameInfo = await this.getPlatform.get('E6ZJ'); // Star Force
+    expect(gameInfo.platform).equals('VC-Arcade');
+    expect(gameInfo.region).equals('Japan');
   });
 
   it('should recognize a WiiWare game', async () => {
-    const platform = await this.getPlatform.get('WKTE'); // Contra Rebirth
-    expect(platform).equals('WiiWare');
+    const gameInfo = await this.getPlatform.get('WKTE'); // Contra Rebirth
+    expect(gameInfo.platform).equals('WiiWare');
+    expect(gameInfo.region).equals('North America');
   });
 
   it('should recognize a Wii game', async () => {
-    const platform = await this.getPlatform.get('R3OP01'); // Metroid: Other M
-    expect(platform).equals('Wii');
+    const gameInfo = await this.getPlatform.get('R3OP01'); // Metroid: Other M
+    expect(gameInfo.platform).equals('Wii');
+    expect(gameInfo.region).equals('Europe');
   });
 
   it('should recognize a Homebrew game', async () => {
-    const platform = await this.getPlatform.get('D40A'); // Luigi and the Island of Mystery
-    expect(platform).equals('Homebrew');
+    const gameInfo = await this.getPlatform.get('D40A'); // Luigi and the Island of Mystery
+    expect(gameInfo.platform).equals('Homebrew');
+    expect(gameInfo.region).equals(GetPlatform.unknownRegion());
   });
 
   it('should recognize a game without a platform listed', async () => {
     // Some titles in the downloadable XML document don't have any platform listed. Those seem to get
     // listed as 'Wii' when viewed on the main site
-    const platform = await this.getPlatform.get('DAXE01'); // The Legend of Zelda: Skyward Sword (Demo)
-    expect(platform).equals('Wii');
+    const gameInfo = await this.getPlatform.get('DAXE01'); // The Legend of Zelda: Skyward Sword (Demo)
+    expect(gameInfo.platform).equals('Wii');
+    expect(gameInfo.region).equals('North America');
   });
 
   it('should not recognize an unknown game', async () => {
-    const platform = await this.getPlatform.get('ABCD');
-    expect(platform).equals(GetPlatform.unknownPlatform());
+    const gameInfo = await this.getPlatform.get('ABCD');
+    expect(gameInfo.platform).equals(GetPlatform.unknownPlatform());
+    expect(gameInfo.region).equals(GetPlatform.unknownRegion());
   });
 });


### PR DESCRIPTION
Some save files found around the Internet are mislabeled and not for the region that they're classified as. This can be confusing because sometimes they won't work when you try to load them up. We have region information for 3 different platforms:
- N64: Display the region in parentheses beside the description of each note
- PS1: Display the region in parentheses beside the description of each save
- Wii VC: Display the region below the platform once a file is specified

For N64, the region can be interpreted from the region code stored with each note. For PS1 it can be gotten from the filename of each save, and for Wii VC we had to parse it from the info returned by gametdb

Fixes https://github.com/euan-forrester/save-file-converter/issues/185