### PR TITLE
Usability fixes

### DIFF
--- a/frontend/src/components/ConvertN64DexDrive.vue
+++ b/frontend/src/components/ConvertN64DexDrive.vue
@@ -136,7 +136,7 @@ export default {
       outputFilename: null,
       conversionDirection: 'convertToEmulator',
       selectedSaveData: null,
-      individualSavesOrMemoryCard: 'individual-saves',
+      individualSavesOrMemoryCard: 'memory-card',
       individualSavesText: 'Individual saves',
       memoryCardText: 'Controller Pak',
     };
@@ -189,7 +189,7 @@ export default {
       this.inputFilename = null;
       this.outputFilename = null;
       this.selectedSaveData = null;
-      this.individualSavesOrMemoryCard = 'individual-saves';
+      this.individualSavesOrMemoryCard = 'memory-card';
     },
     changeSelectedSaveData(newSaveData) {
       if (newSaveData !== null) {

--- a/frontend/src/components/ConvertN64DexDrive.vue
+++ b/frontend/src/components/ConvertN64DexDrive.vue
@@ -46,7 +46,17 @@
             </b-col>
           </b-row>
           <div v-if="this.conversionDirection === 'convertToEmulator'">
-            <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
+            <div v-if="this.individualSavesOrMemoryCard === 'individual-saves'">
+              <output-filename
+                v-model="outputFilename"
+                :leaveRoomForHelpIcon="true"
+                :disabled="true"
+                helpText="The filename for an individual save contains important information that the game needs to find this save data. Please do not modify it after downloading the save."
+              />
+            </div>
+            <div v-else>
+             <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
+            </div>
             <individual-saves-or-memory-card-selector
               :value="this.individualSavesOrMemoryCard"
               @change="changeIndividualSavesOrMemoryCard($event)"

--- a/frontend/src/components/ConvertPs1DexDrive.vue
+++ b/frontend/src/components/ConvertPs1DexDrive.vue
@@ -142,7 +142,7 @@ export default {
       outputFilename: null,
       conversionDirection: 'convertToEmulator',
       selectedSaveData: null,
-      individualSavesOrMemoryCard: 'individual-saves',
+      individualSavesOrMemoryCard: 'memory-card',
       individualSavesText: 'Individual saves',
       memoryCardText: 'Raw/emulator',
     };
@@ -195,7 +195,7 @@ export default {
       this.inputFilename = null;
       this.outputFilename = null;
       this.selectedSaveData = null;
-      this.individualSavesOrMemoryCard = 'individual-saves';
+      this.individualSavesOrMemoryCard = 'memory-card';
     },
     changeSelectedSaveData(newSaveData) {
       if (newSaveData !== null) {
@@ -218,8 +218,7 @@ export default {
 
         this.individualSavesOrMemoryCard = null;
 
-        this.changeIndividualSavesOrMemoryCard('individual-saves');
-        this.changeSelectedSaveData(0);
+        this.changeIndividualSavesOrMemoryCard('memory-card');
       } catch (e) {
         this.errorMessage = 'File appears to not be in the correct format';
         this.dexDriveSaveData = null;

--- a/frontend/src/components/ConvertPs1DexDrive.vue
+++ b/frontend/src/components/ConvertPs1DexDrive.vue
@@ -50,7 +50,17 @@
             </b-col>
           </b-row>
           <div v-if="this.conversionDirection === 'convertToEmulator'">
-            <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
+            <div v-if="this.individualSavesOrMemoryCard === 'individual-saves'">
+              <output-filename
+                v-model="outputFilename"
+                :leaveRoomForHelpIcon="true"
+                :disabled="true"
+                helpText="The filename for an individual save contains important information that the game needs to find this save data. Please do not modify it after downloading the save."
+              />
+            </div>
+            <div v-else>
+             <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
+            </div>
             <individual-saves-or-memory-card-selector
               :value="this.individualSavesOrMemoryCard"
               @change="changeIndividualSavesOrMemoryCard($event)"

--- a/frontend/src/components/ConvertPs1Ps3.vue
+++ b/frontend/src/components/ConvertPs1Ps3.vue
@@ -51,7 +51,17 @@
             </b-col>
           </b-row>
           <div v-if="this.conversionDirection === 'convertToEmulator'">
-            <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
+            <div v-if="this.individualSavesOrMemoryCard === 'individual-saves'">
+              <output-filename
+                v-model="outputFilename"
+                :leaveRoomForHelpIcon="true"
+                :disabled="true"
+                helpText="The filename for an individual save contains important information that the game needs to find this save data. Please do not modify it after downloading the save."
+              />
+            </div>
+            <div v-else>
+             <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
+            </div>
             <individual-saves-or-memory-card-selector
               :value="this.individualSavesOrMemoryCard"
               @change="changeIndividualSavesOrMemoryCard($event)"

--- a/frontend/src/components/ConvertPs1Ps3.vue
+++ b/frontend/src/components/ConvertPs1Ps3.vue
@@ -142,7 +142,7 @@ export default {
       outputFilename: null,
       conversionDirection: 'convertToEmulator',
       selectedSaveData: null,
-      individualSavesOrMemoryCard: 'individual-saves',
+      individualSavesOrMemoryCard: 'memory-card',
       individualSavesText: 'Individual save',
       memoryCardText: 'Raw/emulator',
     };
@@ -201,7 +201,7 @@ export default {
       this.inputFilename = null;
       this.outputFilename = null;
       this.selectedSaveData = null;
-      this.individualSavesOrMemoryCard = 'individual-saves';
+      this.individualSavesOrMemoryCard = 'memory-card';
     },
     changeSelectedSaveData(newSaveData) {
       if (newSaveData !== null) {
@@ -230,8 +230,7 @@ export default {
 
         this.individualSavesOrMemoryCard = null;
 
-        this.changeIndividualSavesOrMemoryCard('individual-saves');
-        this.changeSelectedSaveData(0);
+        this.changeIndividualSavesOrMemoryCard('memory-card');
       } catch (e) {
         this.errorMessage = 'File appears to not be in the correct format';
         this.ps3SaveData = null;

--- a/frontend/src/components/ConvertPs1Psp.vue
+++ b/frontend/src/components/ConvertPs1Psp.vue
@@ -51,7 +51,17 @@
             </b-col>
           </b-row>
           <div v-if="this.conversionDirection === 'convertToEmulator'">
-            <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
+            <div v-if="this.individualSavesOrMemoryCard === 'individual-saves'">
+              <output-filename
+                v-model="outputFilename"
+                :leaveRoomForHelpIcon="true"
+                :disabled="true"
+                helpText="The filename for an individual save contains important information that the game needs to find this save data. Please do not modify it after downloading the save."
+              />
+            </div>
+            <div v-else>
+             <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
+            </div>
             <individual-saves-or-memory-card-selector
               :value="this.individualSavesOrMemoryCard"
               @change="changeIndividualSavesOrMemoryCard($event)"

--- a/frontend/src/components/ConvertPs1Psp.vue
+++ b/frontend/src/components/ConvertPs1Psp.vue
@@ -146,7 +146,7 @@ export default {
       conversionDirection: 'convertToEmulator',
       selectedSaveData: null,
       memoryCardIndex: 0,
-      individualSavesOrMemoryCard: 'individual-saves',
+      individualSavesOrMemoryCard: 'memory-card',
       individualSavesText: 'Individual saves',
       memoryCardText: 'Raw/emulator',
     };
@@ -201,7 +201,7 @@ export default {
       this.outputFilename = null;
       this.selectedSaveData = null;
       this.memoryCardIndex = 0;
-      this.individualSavesOrMemoryCard = 'individual-saves';
+      this.individualSavesOrMemoryCard = 'memory-card';
 
       if (newDirection === 'convertToRetron5') {
         this.changeMemoryCardIndex();
@@ -231,8 +231,7 @@ export default {
 
         this.individualSavesOrMemoryCard = null;
 
-        this.changeIndividualSavesOrMemoryCard('individual-saves');
-        this.changeSelectedSaveData(0);
+        this.changeIndividualSavesOrMemoryCard('memory-card');
       } catch (e) {
         this.errorMessage = 'File appears to not be in the correct format';
         this.pspSaveData = null;

--- a/frontend/src/components/OutputFilename.vue
+++ b/frontend/src/components/OutputFilename.vue
@@ -6,6 +6,7 @@
           v-bind:value="value"
           v-on:input="$emit('input', $event)"
           placeholder="Output filename"
+          :disabled="this.disabled"
         />
         <div v-if="this.helpText !== null">
           <help-button
@@ -45,6 +46,10 @@ export default {
     value: {
       type: String,
       default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
     },
     id: {
       type: String,


### PR DESCRIPTION
- Default to converting an entire memory card for PS1/N64 rather than defaulting to individual saves. Less people use individual saves, and the filenames (particularly with no extension) are confusing -- especially when you're just getting started.
- Disable editing of the filename when converting to an individual save, along with popover help text explaining why