### PR TITLE
Fix incorrect text on raw/emulator side when converting to ps1 dexdrive/psp

### DIFF
--- a/frontend/src/components/ConvertPs1DexDrive.vue
+++ b/frontend/src/components/ConvertPs1DexDrive.vue
@@ -206,6 +206,10 @@ export default {
       this.outputFilename = null;
       this.selectedSaveData = null;
       this.individualSavesOrMemoryCard = 'memory-card';
+
+      if (newDirection === 'convertToFormat') {
+        this.individualSavesOrMemoryCard = 'individual-saves';
+      }
     },
     changeSelectedSaveData(newSaveData) {
       if (newSaveData !== null) {

--- a/frontend/src/components/ConvertPs1Psp.vue
+++ b/frontend/src/components/ConvertPs1Psp.vue
@@ -215,6 +215,7 @@ export default {
 
       if (newDirection === 'convertToFormat') {
         this.changeMemoryCardIndex();
+        this.individualSavesOrMemoryCard = 'individual-saves';
       }
     },
     changeMemoryCardIndex() {


### PR DESCRIPTION
Super confusing that it says it wants a "raw/emulator" file but only actually takes individual saves

Also there's a larger usability issue here whereby users may actually want to convert an entire memory card (to psp, at least) at once and not have to split it up into individual saves first. Created issue https://github.com/euan-forrester/save-file-converter/issues/199 to track this.