### PR TITLE
Allow user to change output filename for cart saves coming from N64 dexdrive/mempack files

### DIFF
--- a/frontend/src/components/ConvertN64DexDrive.vue
+++ b/frontend/src/components/ConvertN64DexDrive.vue
@@ -47,12 +47,19 @@
           </b-row>
           <div v-if="this.conversionDirection === 'convertToRaw'">
             <div v-if="this.individualSavesOrMemoryCard === 'individual-saves'">
-              <output-filename
-                v-model="outputFilename"
-                :leaveRoomForHelpIcon="true"
-                :disabled="true"
-                helpText="The filename for an individual save contains important information that the game needs to find this save data. Please do not modify it after downloading the save."
-              />
+              <div v-if="this.userAllowedToChangeFilename">
+                <output-filename
+                  v-model="outputFilename"
+                />
+              </div>
+              <div v-else>
+                <output-filename
+                  v-model="outputFilename"
+                  :leaveRoomForHelpIcon="true"
+                  :disabled="true"
+                  helpText="The filename for an individual save contains important information that the game needs to find this save data. Please do not modify it after downloading the save."
+                />
+              </div>
             </div>
             <div v-else>
              <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
@@ -166,6 +173,10 @@ export default {
     },
     individualSavesOrMemoryCardText() {
       return (this.individualSavesOrMemoryCard === 'individual-saves') ? this.individualSavesText : this.memoryCardText;
+    },
+    userAllowedToChangeFilename() {
+      return !this.dexDriveSaveData
+        || ((this.dexDriveSaveData.getSaveFiles().length > 0) && (this.selectedSaveData !== null) && N64MempackSaveData.isCartSave(this.dexDriveSaveData.getSaveFiles()[this.selectedSaveData]));
     },
   },
   methods: {

--- a/frontend/src/components/ConvertN64Mempack.vue
+++ b/frontend/src/components/ConvertN64Mempack.vue
@@ -46,12 +46,19 @@
             </b-col>
           </b-row>
           <div v-if="this.conversionDirection === 'convertToRaw'">
-            <output-filename
-              v-model="outputFilename"
-              :leaveRoomForHelpIcon="true"
-              :disabled="true"
-              helpText="The filename for an individual save contains important information that the game needs to find this save data. Please do not modify it after downloading the save."
-            />
+            <div v-if="this.userAllowedToChangeFilename">
+              <output-filename
+                v-model="outputFilename"
+              />
+            </div>
+            <div v-else>
+              <output-filename
+                v-model="outputFilename"
+                :leaveRoomForHelpIcon="true"
+                :disabled="true"
+                helpText="The filename for an individual save contains important information that the game needs to find this save data. Please do not modify it after downloading the save."
+              />
+            </div>
           </div>
           <div v-else>
             <input-file
@@ -146,6 +153,10 @@ export default {
       const haveDataSelected = (this.conversionDirection === 'convertToRaw') ? true : this.selectedSaveData === null;
 
       return !this.mempackSaveData || this.mempackSaveData.getSaveFiles().length === 0 || !haveDataSelected || !this.outputFilename;
+    },
+    userAllowedToChangeFilename() {
+      return !this.mempackSaveData
+        || ((this.mempackSaveData.getSaveFiles().length > 0) && (this.selectedSaveData !== null) && N64MempackSaveData.isCartSave(this.mempackSaveData.getSaveFiles()[this.selectedSaveData]));
     },
   },
   methods: {


### PR DESCRIPTION
We grey out the output filename for individual saves because it contains information like the note name, publisher code, etc that needs to be put in the note table when the save is added to a mempack image.

But for a cart save, this information isn't very useful and the user will almost certainly need to edit the name to make the file get loaded by an emulator, etc. So we don't want to confuse users here by stating that they can't change the filename for these saves.

Fixes https://github.com/euan-forrester/save-file-converter/issues/223