### PR TITLE
Added region codes for Gateway 64 to the N64 mempack parsing

### DIFF
--- a/frontend/src/save-formats/N64/Mempack.js
+++ b/frontend/src/save-formats/N64/Mempack.js
@@ -87,10 +87,12 @@ const REGION_CODE_TO_NAME = {
   D: 'Germany',
   E: 'North America',
   F: 'France',
+  G: 'Gateway 64 (NTSC)',
   H: 'Netherlands', // Unused. GC/Wii only.
   I: 'Italy',
   J: 'Japan',
   K: 'South Korea', // Unused. GC/Wii only.
+  L: 'Gateway 64 (PAL)',
   P: 'Europe',
   R: 'Russia', // Unused. Wii only.
   S: 'Spain',


### PR DESCRIPTION
Fixes https://github.com/euan-forrester/save-file-converter/issues/243