### PR TITLE
Fix links to the specific platforms for cheatcc.com

### DIFF
--- a/frontend/src/views/DownloadSaves.vue
+++ b/frontend/src/views/DownloadSaves.vue
@@ -42,7 +42,7 @@
       </b-col>
       <b-col cols=12 md=5 lg=5 xl=4>
         Has saves for some specific systems:
-        <b-link href="https://www.cheatcc.com/n64/sgf/index.html">N64</b-link>,{{'\xa0'}}<b-link href="https://cheatcc.com/pc/sgf/">PC</b-link>,{{'\xa0'}}<b-link href="https://www.cheatcc.com/psx/sgf/index.html">PS1</b-link>
+        <b-link href="http://news1.cheatcc.com/n64/sgf/index.html">N64</b-link>,{{'\xa0'}}<b-link href="http://news1.cheatcc.com/pc/sgf/index.html">PC</b-link>,{{'\xa0'}}<b-link href="http://news1.cheatcc.com/psx/sgf/index.html">PS1</b-link>
       </b-col>
     </b-row>
     <div class="blank-line"/>


### PR DESCRIPTION
Looks like cheatcc.com reorganized their site. This fixes the links to the pages that list saves for particular systems.