### PR TITLE
Fixed bug with resizing some saves

### DIFF
--- a/frontend/src/components/ConvertFlashCarts.vue
+++ b/frontend/src/components/ConvertFlashCarts.vue
@@ -586,6 +586,8 @@ export default {
       this.updateFlashCartSaveData();
     },
     convertFile() {
+      let finalFlashCartSaveData = this.flashCartSaveData;
+
       let needsResize = false;
 
       if (this.isSegaCd) {
@@ -595,22 +597,22 @@ export default {
       }
 
       if (needsResize) {
-        this.flashCartSaveData = this.flashCartTypeClass.createWithNewSize(this.flashCartSaveData, this.outputFilesize);
+        finalFlashCartSaveData = this.flashCartTypeClass.createWithNewSize(this.flashCartSaveData, this.outputFilesize);
       }
 
       let output = null;
 
       if (this.conversionDirection === 'convertToRaw') {
         if (this.isSegaCd) {
-          output = this.flashCartSaveData.getRawArrayBuffer(this.segaCdSaveType);
+          output = finalFlashCartSaveData.getRawArrayBuffer(this.segaCdSaveType);
         } else {
-          output = this.flashCartSaveData.getRawArrayBuffer();
+          output = finalFlashCartSaveData.getRawArrayBuffer();
         }
       } else {
         if (this.isSegaCd) { // eslint-disable-line no-lonely-if
-          output = this.flashCartSaveData.getFlashCartArrayBuffer(this.segaCdSaveType);
+          output = finalFlashCartSaveData.getFlashCartArrayBuffer(this.segaCdSaveType);
         } else {
-          output = this.flashCartSaveData.getFlashCartArrayBuffer();
+          output = finalFlashCartSaveData.getFlashCartArrayBuffer();
         }
       }
 

--- a/frontend/src/components/ConvertGbaActionReplay.vue
+++ b/frontend/src/components/ConvertGbaActionReplay.vue
@@ -149,11 +149,13 @@ export default {
       }
     },
     convertFile() {
+      let finalActionReplaySaveData = this.actionReplaySaveData;
+
       if (this.actionReplaySaveData.getRawSaveData().byteLength !== this.outputFilesize) {
-        this.actionReplaySaveData = ActionReplaySaveData.createWithNewSize(this.actionReplaySaveData, this.outputFilesize);
+        finalActionReplaySaveData = ActionReplaySaveData.createWithNewSize(this.actionReplaySaveData, this.outputFilesize);
       }
 
-      const outputArrayBuffer = (this.conversionDirection === 'convertToRaw') ? this.actionReplaySaveData.getRawSaveData() : this.actionReplaySaveData.getArrayBuffer();
+      const outputArrayBuffer = (this.conversionDirection === 'convertToRaw') ? finalActionReplaySaveData.getRawSaveData() : finalActionReplaySaveData.getArrayBuffer();
 
       const outputBlob = new Blob([outputArrayBuffer], { type: 'application/octet-stream' });
 

--- a/frontend/src/components/ConvertGbaGameShark.vue
+++ b/frontend/src/components/ConvertGbaGameShark.vue
@@ -193,11 +193,13 @@ export default {
       }
     },
     convertFile() {
+      let finalGameSharkSaveData = this.gameSharkSaveData;
+
       if (this.gameSharkSaveData.getRawSaveData().byteLength !== this.outputFilesize) {
-        this.gameSharkSaveData = GameSharkSaveData.createWithNewSize(this.gameSharkSaveData, this.outputFilesize);
+        finalGameSharkSaveData = GameSharkSaveData.createWithNewSize(this.gameSharkSaveData, this.outputFilesize);
       }
 
-      const outputArrayBuffer = (this.conversionDirection === 'convertToRaw') ? this.gameSharkSaveData.getRawSaveData() : this.gameSharkSaveData.getArrayBuffer();
+      const outputArrayBuffer = (this.conversionDirection === 'convertToRaw') ? finalGameSharkSaveData.getRawSaveData() : finalGameSharkSaveData.getArrayBuffer();
 
       const outputBlob = new Blob([outputArrayBuffer], { type: 'application/octet-stream' });
 

--- a/frontend/src/components/ConvertMister.vue
+++ b/frontend/src/components/ConvertMister.vue
@@ -373,6 +373,8 @@ export default {
       this.updateMisterSaveData();
     },
     convertFile() {
+      let finalMisterSaveData = this.misterSaveData;
+
       let needsResize = false;
 
       if (this.isSegaCd) {
@@ -382,19 +384,19 @@ export default {
       }
 
       if (needsResize) {
-        this.misterSaveData = this.misterPlatformClass.createWithNewSize(this.misterSaveData, this.outputFilesize);
+        finalMisterSaveData = this.misterPlatformClass.createWithNewSize(this.misterSaveData, this.outputFilesize);
       }
 
       let output = null;
 
       if (this.conversionDirection === 'convertToRaw') {
         if (this.isSegaCd) {
-          output = this.misterSaveData.getRawArrayBuffer(this.segaCdSaveType);
+          output = finalMisterSaveData.getRawArrayBuffer(this.segaCdSaveType);
         } else {
-          output = this.misterSaveData.getRawArrayBuffer();
+          output = finalMisterSaveData.getRawArrayBuffer();
         }
       } else {
-        output = this.misterSaveData.getMisterArrayBuffer();
+        output = finalMisterSaveData.getMisterArrayBuffer();
       }
 
       const outputBlob = new Blob([output], { type: 'application/octet-stream' });

--- a/frontend/src/components/ConvertNintendoSwitchOnline.vue
+++ b/frontend/src/components/ConvertNintendoSwitchOnline.vue
@@ -305,16 +305,18 @@ export default {
       this.updateNsoSaveData();
     },
     convertFile() {
+      let finalNsoSaveData = this.nsoSaveData;
+
       if (this.nsoSaveData.getRawArrayBuffer().byteLength !== this.outputFilesize) {
-        this.nsoSaveData = this.nsoPlatformClass.createWithNewSize(this.nsoSaveData, this.outputFilesize);
+        finalNsoSaveData = this.nsoPlatformClass.createWithNewSize(this.nsoSaveData, this.outputFilesize);
       }
 
       let output = null;
 
       if (this.conversionDirection === 'convertToRaw') {
-        output = this.nsoSaveData.getRawArrayBuffer();
+        output = finalNsoSaveData.getRawArrayBuffer();
       } else {
-        output = this.nsoSaveData.getNsoArrayBuffer();
+        output = finalNsoSaveData.getNsoArrayBuffer();
       }
 
       const outputBlob = new Blob([output], { type: 'application/octet-stream' });


### PR DESCRIPTION
In some instances, resizing a save to be smaller, and then bigger would result in errors in the console window + the button not working, or returning a file with some data zeroed out at the end.

This was because we were stomping over the user-supplied file when resizing. 

Fixes https://github.com/euan-forrester/save-file-converter/issues/261