### PR TITLE
Online emulator cleanup tasks

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta name="robots" content="max-image-preview:none">
-    <meta name="description" content="Converts save files for retro consoles: MiSTer, GameShark (sps and gsv), PS1, N64, DexDrive, Action Replay, Retron 5, Wii Virtual Console, Sega CD, Nintendo Switch Online, emulators, and various flash cartridge formats. Decrypts PSP saves. Provides help for downloading save files, erasing cartridge saves, and copying saves to and from original hardware." />
+    <meta name="description" content="Converts save files for retro consoles: MiSTer, GameShark (sps and gsv), PS1, N64, DexDrive, Action Replay, Retron 5, Wii Virtual Console, Sega CD, Nintendo Switch Online, emulators, various flash cartridge formats, and save states from online emulation websites. Decrypts PSP saves. Provides help for downloading save files, erasing cartridge saves, and copying saves to and from original hardware." />
     <link rel="apple-touch-icon" sizes="180x180" href="<%= BASE_URL %>apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="<%= BASE_URL %>favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="<%= BASE_URL %>favicon-16x16.png">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,20 +3,20 @@
     <div id="nav">
       <b-row>
         <b-col class="nav-row">
-          <router-link to="/retron-5">Retron{{'\xa0'}}5 / RetroFreak</router-link>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col class="nav-row">
           <router-link to="/mister">MiSTer</router-link> |
-          <router-link to="/flash-carts">Flash cartridges</router-link> |
-          <router-link to="/online-emulators">Online{{'\xa0'}}emulators{{'\xa0'}}<span class="beta-text">(Beta)</span></router-link>
+          <router-link to="/flash-carts">Flash cartridges</router-link>
         </b-col>
       </b-row>
       <b-row>
         <b-col class="nav-row">
-          <router-link to="/nintendo-switch-online">Nintendo{{'\xa0'}}Switch{{'\xa0'}}Online{{'\xa0'}}</router-link> |
+          <router-link to="/nintendo-switch-online">Nintendo{{'\xa0'}}Switch{{'\xa0'}}Online</router-link> |
           <router-link to="/wii">Wii{{'\xa0'}}Virtual{{'\xa0'}}Console</router-link>
+        </b-col>
+      </b-row>
+      <b-row>
+        <b-col class="nav-row">
+          <router-link to="/retron-5">Retron{{'\xa0'}}5 / RetroFreak</router-link> |
+          <router-link to="/online-emulators">Online{{'\xa0'}}emulators{{'\xa0'}}<span class="beta-text">(Beta)</span></router-link>
         </b-col>
       </b-row>
       <b-row>


### PR DESCRIPTION
- Updated the site description for google to include the new functionality
- Reorganized the nav: moved retron5 from the top since it hasn't been the most popular conversion for a long time now, and put this new route beside it
- Updated https://emulation.gametechwiki.com/index.php/Save_converters
- Updated the repo description on github

Fixes https://github.com/euan-forrester/save-file-converter/issues/277