### PR TITLE
Updated message regarding converting to a Wii VC save file

### DIFF
--- a/frontend/src/components/ConvertWii.vue
+++ b/frontend/src/components/ConvertWii.vue
@@ -44,7 +44,7 @@
           />
           <b-popover target="conversion-direction" triggers="focus hover" placement="bottom">
             We can currently only extract the raw save from Wii Virtual Console files.
-            If converting raw saves to Wii Virtual Console files is important to you, please let us know! Contact info on the About / Contact page.
+            If you need to convert to a Wii Virtual Console file, please google the tool named FE100.
           </b-popover>
         </b-col>
         <b-col sm=12 md=5 align-self="start">


### PR DESCRIPTION
The old message asking people to request support for converting to Wii VC files has done its job: almost nobody requested it, and almost all of those who did were only mildly interested in adding this feature.

So this changes the message to point people to FE100 instead. I've not used it personally, but it purports to be able to pack saves into the Wii VC format. It's too old and looks too difficult to get running to be worth listing in `/other-converters`

Fixes https://github.com/euan-forrester/save-file-converter/issues/282