### PR TITLE
Fixed glitchy UI when selecting a save state that the site does not support

### DIFF
--- a/frontend/src/components/ConvertOnlineEmulators.vue
+++ b/frontend/src/components/ConvertOnlineEmulators.vue
@@ -230,11 +230,9 @@ export default {
             this.outputFilesize = this.getDefaultOutputFilesize();
           }
         } catch (e) {
-          this.errorMessage = 'This file does not seem to be in the correct format';
+          this.errorMessage = 'This file does not appear to be a save state that this site is able to currently support. '
+            + 'If this is a save state from an online emulator and you would like to request adding support for it, please visit the Discord / Contact page.';
           this.onlineEmulatorWrapper = null;
-          this.outputFilename = null;
-          this.selectedSaveData = null;
-          this.outputFilesize = null;
         }
       } else {
         this.onlineEmulatorWrapper = null;

--- a/frontend/src/save-formats/OnlineEmulators/Emulators/VBA-Next.js
+++ b/frontend/src/save-formats/OnlineEmulators/Emulators/VBA-Next.js
@@ -42,6 +42,10 @@ function getRawArrayBufferFromSaveStateArrayBuffer(emulatorSaveStateArrayBuffer,
 
   const rawSaveOffset = SAVE_OFFSET[saveSize];
 
+  if (rawSaveOffset > emulatorSaveStateArrayBuffer.byteLength) {
+    throw new Error('This does not appear to be a VBA-Next save state file');
+  }
+
   return emulatorSaveStateArrayBuffer.slice(rawSaveOffset, rawSaveOffset + saveSize);
 }
 

--- a/frontend/src/save-formats/OnlineEmulators/Emulators/VBA-Next.js
+++ b/frontend/src/save-formats/OnlineEmulators/Emulators/VBA-Next.js
@@ -42,7 +42,7 @@ function getRawArrayBufferFromSaveStateArrayBuffer(emulatorSaveStateArrayBuffer,
 
   const rawSaveOffset = SAVE_OFFSET[saveSize];
 
-  if (rawSaveOffset > emulatorSaveStateArrayBuffer.byteLength) {
+  if ((rawSaveOffset + saveSize) > emulatorSaveStateArrayBuffer.byteLength) {
     throw new Error('This does not appear to be a VBA-Next save state file');
   }
 


### PR DESCRIPTION
The UI at `/online-emulators` would glitch out if provided with a file that was too short to be a VBA Next save state. See issue linked below for details.

Fixed this by adding a test when trying to convert the save. Previously, the conversion would just output a zero-length file, which then would be an error when setting that size in the UI and then re-converting the file (ugh).

Fixed https://github.com/euan-forrester/save-file-converter/issues/289