### PR TITLE
Added converter for .srm to .sav and vice versa

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.34",
-    "@fortawesome/free-solid-svg-icons": "^5.15.2",
+    "@fortawesome/free-solid-svg-icons": "^6.5.0",
     "@fortawesome/vue-fontawesome": "^2.0.2",
     "@gtm-support/vue2-gtm": "^1.2.0",
     "axios": "^0.21.2",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,6 +8,16 @@
       </b-row>
       <b-row>
         <b-col class="nav-row">
+          <router-link to="/srm-sav">
+            .srm{{'\xa0'}}
+            <span class="arrow-spacing"><i class="fa fa-arrow-right-arrow-left"></i></span>
+            {{'\xa0'}}.sav{{'\xa0'}}
+            <span class="beta-text">(Beta)</span>
+          </router-link>
+        </b-col>
+      </b-row>
+      <b-row>
+        <b-col class="nav-row">
           <router-link to="/flash-carts">Flash{{'\xa0'}}cartridges{{'\xa0'}}/ original{{'\xa0'}}cartridges</router-link>
         </b-col>
       </b-row>
@@ -94,6 +104,11 @@
 
 #nav a.router-link-exact-active {
   color: #42b983;
+}
+
+.arrow-spacing {
+  padding-left: 0.1em;
+  padding-right: 0.1em;
 }
 
 .nav-row {

--- a/frontend/src/components/ConvertSrmSav.vue
+++ b/frontend/src/components/ConvertSrmSav.vue
@@ -85,7 +85,7 @@
 
 <style scoped>
 
-.action-replay-convert-button {
+.srm-sav-convert-button {
   margin-top: 1em;
 }
 

--- a/frontend/src/components/ConvertSrmSav.vue
+++ b/frontend/src/components/ConvertSrmSav.vue
@@ -1,0 +1,161 @@
+<template>
+  <div>
+    <b-container>
+      <b-row no-gutters align-h="center" align-v="start">
+        <b-col sm=12 md=5 align-self="start">
+          <b-row no-gutters align-h="center" align-v="start">
+            <b-col cols=12>
+              <b-jumbotron fluid :header-level="$mq | mq({ xs: 5, sm: 5, md: 5, lg: 5, xl: 4 })">
+                <template v-slot:header>.srm</template>
+              </b-jumbotron>
+            </b-col>
+          </b-row>
+          <div v-if="this.conversionDirection === 'convertToRaw'">
+            <input-file
+              @load="readSrmSaveData($event)"
+              :errorMessage="this.errorMessage"
+              placeholderText="Choose a file to convert (*.srm)"
+              acceptExtension=".srm"
+              :leaveRoomForHelpIcon="false"
+            />
+          </div>
+          <div v-else>
+            <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
+            <!-- Here we omit having a output file size selector because we're going to likely be given all sorts of different files and many may not be in powers-of-2 -->
+          </div>
+        </b-col>
+        <b-col sm=12 md=2 lg=2 xl=2 align-self="start">
+          <conversion-direction
+            :horizontalLayout="['md', 'lg', 'xl']"
+            :verticalLayout="['xs', 'sm']"
+            :conversionDirection="this.conversionDirection"
+            @change="changeConversionDirection($event)"
+          />
+        </b-col>
+        <b-col sm=12 md=5 align-self="start">
+          <b-row no-gutters align-h="center" align-v="start">
+            <b-col cols=12>
+              <b-jumbotron fluid :header-level="$mq | mq({ xs: 5, sm: 5, md: 5, lg: 5, xl: 4 })">
+                <template v-slot:header>.sav</template>
+              </b-jumbotron>
+            </b-col>
+          </b-row>
+          <div v-if="this.conversionDirection === 'convertToRaw'">
+            <output-filename v-model="outputFilename" :leaveRoomForHelpIcon="false"/>
+            <!-- Here we omit having a output file size selector because we're going to likely be given all sorts of different files and many may not be in powers-of-2 -->
+          </div>
+          <div v-else>
+            <input-file
+              @load="readSavSaveData($event)"
+              :errorMessage="this.errorMessage"
+              placeholderText="Choose a file to convert (*.sav)"
+              acceptExtension=".sav"
+              :leaveRoomForHelpIcon="false"
+            />
+          </div>
+        </b-col>
+      </b-row>
+      <b-row class="justify-content-md-center" align-h="center">
+        <b-col cols="auto" sm=4 md=3 lg=2 align-self="center">
+          <b-button
+            class="srm-sav-convert-button"
+            variant="success"
+            block
+            :disabled="!this.saveData || !outputFilename"
+            @click="convertFile()"
+          >
+          Convert!
+          </b-button>
+        </b-col>
+      </b-row>
+      <b-row>
+        <b-col>
+          <div class="help">
+            This may not result in a usable .sav file from all .srm files, or vice versa.
+          </div>
+          <div class="help">
+            If you have a save file from a specific place like the <router-link to="/mister">MiSTer</router-link>,
+            a <router-link to="/flash-carts">flash cart</router-link>, or the <router-link to="/retron-5">Retron 5</router-link> then please use one of those conversions instead.
+          </div>
+        </b-col>
+      </b-row>
+    </b-container>
+  </div>
+</template>
+
+<style scoped>
+
+.action-replay-convert-button {
+  margin-top: 1em;
+}
+
+.help {
+  margin-top: 1em;
+}
+</style>
+
+<script>
+import { saveAs } from 'file-saver';
+import Util from '../util/util';
+import InputFile from './InputFile.vue';
+import OutputFilename from './OutputFilename.vue';
+import ConversionDirection from './ConversionDirection.vue';
+
+export default {
+  name: 'ConvertSrmSav',
+  data() {
+    return {
+      saveData: null,
+      errorMessage: null,
+      outputFilename: null,
+      conversionDirection: 'convertToRaw',
+    };
+  },
+  components: {
+    ConversionDirection,
+    InputFile,
+    OutputFilename,
+  },
+  methods: {
+    changeConversionDirection(newDirection) {
+      this.conversionDirection = newDirection;
+      this.saveData = null;
+      this.errorMessage = null;
+      this.outputFilename = null;
+    },
+    readSrmSaveData(event) {
+      this.errorMessage = null;
+      try {
+        this.saveData = event.arrayBuffer;
+        this.outputFilename = Util.changeFilenameExtension(event.filename, 'sav');
+      } catch (e) {
+        this.errorMessage = e.message;
+        this.saveData = null;
+      }
+    },
+    readSavSaveData(event) {
+      this.errorMessage = null;
+      try {
+        this.saveData = event.arrayBuffer;
+        this.outputFilename = Util.changeFilenameExtension(event.filename, 'srm');
+      } catch (e) {
+        this.errorMessage = e.message;
+        this.saveData = null;
+      }
+    },
+    convertFile() {
+      // This "conversion" does nothing but change the extension of the file. Having a different file extension than expected by their
+      // emulator is a huge stumbling block for many people. We are conditioned by our operating systems to treat file extensions seriously,
+      // and that they represent the format of the data in the file. However, many emulators (and other ways of playing retro games) use
+      // the extensions .srm and .sav interchangably, and they do not represent anything about the data contained in the file.
+      // "convert srm to sav" and vice versa continue to be top google searches in the save file converter space, indicating that this is an
+      // ongoing problem for users
+
+      const outputBlob = new Blob([this.saveData], { type: 'application/octet-stream' });
+
+      saveAs(outputBlob, this.outputFilename); // Frustratingly, in Firefox the dialog says "from: blob:" and apparently this can't be changed: https://github.com/eligrey/FileSaver.js/issues/101
+    },
+  },
+};
+
+</script>

--- a/frontend/src/plugins/fontawesome-vue.js
+++ b/frontend/src/plugins/fontawesome-vue.js
@@ -6,6 +6,7 @@ import {
   faArrowCircleRight,
   faArrowCircleUp,
   faArrowCircleDown,
+  faArrowRightArrowLeft,
   faQuestionCircle,
   faCheck,
   faTimes,
@@ -18,6 +19,7 @@ library.add(faArrowCircleLeft);
 library.add(faArrowCircleRight);
 library.add(faArrowCircleUp);
 library.add(faArrowCircleDown);
+library.add(faArrowRightArrowLeft);
 library.add(faQuestionCircle);
 library.add(faCheck);
 library.add(faTimes);

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -111,6 +111,11 @@ const routes = [
     component: () => import(/* webpackChunkName: "nintendo-switch-online" */ '../views/NintendoSwitchOnline.vue'),
   },
   {
+    path: '/srm-sav',
+    name: '.srm to/from .sav',
+    component: () => import(/* webpackChunkName: "srm-sav" */ '../views/SrmSav.vue'),
+  },
+  {
     path: '/utilities',
     redirect: '/utilities/troubleshooting',
   },

--- a/frontend/src/views/SrmSav.vue
+++ b/frontend/src/views/SrmSav.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="home">
+    <ConvertSrmSav/>
+  </div>
+</template>
+
+<script>
+// @ is an alias to /src
+import ConvertSrmSav from '@/components/ConvertSrmSav.vue';
+
+export default {
+  name: 'SrmSavView',
+  components: {
+    ConvertSrmSav,
+  },
+};
+</script>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1024,10 +1024,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-common-types@^0.2.36":
-  version "0.2.36"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
-  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
+"@fortawesome/fontawesome-common-types@6.5.2":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz#eaf2f5699f73cef198454ebc0c414e3688898179"
+  integrity sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==
 
 "@fortawesome/fontawesome-common-types@^0.3.0":
   version "0.3.0"
@@ -1041,12 +1041,12 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.3.0"
 
-"@fortawesome/free-solid-svg-icons@^5.15.2":
-  version "5.15.4"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"
-  integrity sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==
+"@fortawesome/free-solid-svg-icons@^6.5.0":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz#9b40b077b27400a5e9fcbf2d15b986c7be69e9ca"
+  integrity sha512-QWFZYXFE7O1Gr1dTIp+D6UcFUF0qElOnZptpi7PBUMylJh+vFmIedVe1Ir6RM1t2tEQLLSV1k7bR4o92M+uqlw==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.36"
+    "@fortawesome/fontawesome-common-types" "6.5.2"
 
 "@fortawesome/vue-fontawesome@^2.0.2":
   version "2.0.10"


### PR DESCRIPTION
This "conversion" does nothing but change the extension of the file. Having a different file extension than expected by their
emulator is a huge stumbling block for many people. We are conditioned by our operating systems to treat file extensions seriously, and that they represent the format of the data in the file. However, many emulators (and other ways of playing retro games) use the extensions `.srm` and `.sav` interchangably, and they do not represent anything about the data contained in the file. 

"convert srm to sav" and vice versa continue to be top google searches in the save file converter space, indicating that this is an ongoing problem for users

Other changes:
- Upgraded `@fortawesome/free-solid-svg-icons` to `6.5.0` to add support for left/right arrow

Fixes https://github.com/euan-forrester/save-file-converter/issues/257