### PR TITLE
Change size of Mega Everdrive Pro's Sega CD saves to reflect new firmware

### DIFF
--- a/frontend/src/save-formats/FlashCarts/Genesis/MegaEverdrivePro/SegaCd.js
+++ b/frontend/src/save-formats/FlashCarts/Genesis/MegaEverdrivePro/SegaCd.js
@@ -5,7 +5,7 @@ export default class GenesisMegaEverdriveProSegaCdFlashCartSaveData {
 
   static RAM_CART = 'ram-cart';
 
-  static FLASH_CART_RAM_CART_SIZE = 262144; // The Mega Everdrive Pro produces RAM cart files of this size
+  static FLASH_CART_RAM_CART_SIZE = 131072; // The Mega Everdrive Pro produces RAM cart files of this size
 
   static EMULATOR_RAM_CART_SIZE = 524288; // The emulators I've seen produce a RAM cart file of this size (note that the output size is changeable by the user)
 

--- a/frontend/src/save-formats/FlashCarts/Genesis/MegaEverdrivePro/SegaCd.js
+++ b/frontend/src/save-formats/FlashCarts/Genesis/MegaEverdrivePro/SegaCd.js
@@ -5,7 +5,7 @@ export default class GenesisMegaEverdriveProSegaCdFlashCartSaveData {
 
   static RAM_CART = 'ram-cart';
 
-  static FLASH_CART_RAM_CART_SIZE = 131072; // The Mega Everdrive Pro produces RAM cart files of this size
+  static FLASH_CART_RAM_CART_SIZE = 131072; // The Mega Everdrive Pro produces RAM cart files of this size as of firmware v24.1129
 
   static EMULATOR_RAM_CART_SIZE = 524288; // The emulators I've seen produce a RAM cart file of this size (note that the output size is changeable by the user)
 


### PR DESCRIPTION
As of firmware `v24.1129` the Mega Everdrive Pro produces Sega CD files that are 128kB instead of 256kB: https://krikzz.com/pub/support/mega-everdrive/pro-series/firmware/changelog.txt

Fixes https://github.com/euan-forrester/save-file-converter/issues/326