### PR TITLE
Added Saturn to the MiSTer UI

### DIFF
--- a/frontend/src/components/ConvertMister.vue
+++ b/frontend/src/components/ConvertMister.vue
@@ -50,6 +50,7 @@
               <sega-cd-save-type-selector
                 :value="this.segaCdSaveType"
                 @change="changeSegaCdSaveType($event)"
+                :ramCartText="this.misterPlatform === 'Mister-SAT' ? 'Backup cartridge' : 'RAM cartridge'"
               />
             </div>
             <div v-if="this.displayOutputFileSize">
@@ -66,7 +67,7 @@
                 ref="inputFileSegaCdInternalMemory"
               />
               <input-file
-                @load="readEmulatorSaveData($event, 'rawRamCartSaveArrayBuffer')"
+                @load="readEmulatorSaveData($event, 'rawCartSaveArrayBuffer')"
                 :errorMessage="this.errorMessage"
                 placeholderText="Choose a RAM cartridge save file to convert"
                 :leaveRoomForHelpIcon="false"
@@ -140,6 +141,7 @@ import MisterGameGearSaveData from '../save-formats/Mister/GameGear';
 import MisterSmsSaveData from '../save-formats/Mister/Sms';
 import MisterGenesisSaveData from '../save-formats/Mister/Genesis';
 import MisterSegaCdSaveData from '../save-formats/Mister/SegaCd';
+import MisterSegaSaturnSaveData from '../save-formats/Mister/SegaSaturn';
 import MisterPcEngineSaveData from '../save-formats/Mister/PcEngine';
 import MisterPs1SaveData from '../save-formats/Mister/Ps1';
 import MisterWonderSwanSaveData from '../save-formats/Mister/WonderSwan';
@@ -173,7 +175,7 @@ export default {
   },
   computed: {
     isSegaCd: {
-      get() { return (this.misterPlatform === 'Mister-MCD'); },
+      get() { return (this.misterPlatform === 'Mister-MCD') || (this.misterPlatform === 'Mister-SAT'); },
     },
     displayOutputFileSize: {
       get() {
@@ -214,7 +216,7 @@ export default {
     getSegaCdRawFileName() {
       const filenameSuffix = (this.segaCdSaveType === 'internal-memory') ? ' - internal memory' : ' - ram cartridge';
 
-      return `${Util.removeFilenameExtension(this.inputFilename)}${filenameSuffix}.${this.misterPlatformClass.getRawFileExtension(this.inputArrayBuffer)}`;
+      return `${Util.removeFilenameExtension(this.inputFilename)}${filenameSuffix}.${this.misterPlatformClass.getRawFileExtension(this.segaCdSaveType)}`;
     },
     misterPlatformChanged() {
       if (this.misterPlatform !== null) {
@@ -266,6 +268,11 @@ export default {
 
           case 'Mister-MCD': {
             this.misterPlatformClass = MisterSegaCdSaveData;
+            break;
+          }
+
+          case 'Mister-SAT': {
+            this.misterPlatformClass = MisterSegaSaturnSaveData;
             break;
           }
 

--- a/frontend/src/components/ConvertMister.vue
+++ b/frontend/src/components/ConvertMister.vue
@@ -61,14 +61,14 @@
             <div v-if="this.isSegaCd">
               <input-file
                 @load="readEmulatorSaveData($event, 'rawInternalSaveArrayBuffer')"
-                :errorMessage="this.errorMessage"
+                :errorMessage="this.segaCdErrorMessage"
                 placeholderText="Choose an internal memory save file to convert"
                 :leaveRoomForHelpIcon="false"
                 ref="inputFileSegaCdInternalMemory"
               />
               <input-file
                 @load="readEmulatorSaveData($event, 'rawCartSaveArrayBuffer')"
-                :errorMessage="this.errorMessage"
+                :errorMessage="this.segaCdErrorMessage"
                 placeholderText="Choose a RAM cartridge save file to convert"
                 :leaveRoomForHelpIcon="false"
                 ref="inputFileSegaCdRamCart"
@@ -155,6 +155,7 @@ export default {
       misterPlatformPrevious: null,
       misterPlatformClass: null,
       errorMessage: null,
+      segaCdErrorMessage: null,
       outputFilename: null,
       outputFilesize: null,
       conversionDirection: 'convertToRaw',
@@ -199,6 +200,7 @@ export default {
       this.misterPlatformPrevious = null;
       this.misterPlatformClass = null;
       this.errorMessage = null;
+      this.segaCdErrorMessage = null;
       this.outputFilename = null;
       this.outputFilesize = null;
       this.inputArrayBuffer = null;
@@ -308,10 +310,7 @@ export default {
       // in the same location as a previous one, then the contents of the file box in the DOM carry over to the new box
       // even though it's a different element. So, we call reset() here
 
-      const currentlySegaCd = this.isSegaCd;
-      const previouslySegaCd = (this.misterPlatformPrevious === 'Mister-MCD');
-
-      if ((currentlySegaCd !== previouslySegaCd) && (this.conversionDirection !== 'convertToRaw')) {
+      if ((this.misterPlatform !== this.misterPlatformPrevious) && (this.conversionDirection !== 'convertToRaw')) {
         this.inputFileType = null;
         this.inputArrayBuffer = null;
         this.inputFilename = null;
@@ -332,8 +331,9 @@ export default {
 
       this.updateMisterSaveData();
     },
-    updateMisterSaveData() {
+    updateMisterSaveData(inputSegaCdType) {
       this.errorMessage = null;
+      this.segaCdErrorMessage = null;
       this.outputFilesize = null;
 
       if ((this.misterPlatformClass !== null) && (this.inputArrayBuffer !== null) && (this.inputFilename !== null) && (this.inputFileType !== null)) {
@@ -360,7 +360,11 @@ export default {
             this.outputFilesize = this.misterSaveData.getRawArrayBuffer().byteLength;
           }
         } catch (e) {
-          this.errorMessage = 'This file does not seem to be in the correct format';
+          if (inputSegaCdType === null) {
+            this.errorMessage = 'This file does not seem to be in the correct format';
+          } else {
+            this.segaCdErrorMessage = 'At least one of these files does not seem to be in the correct format';
+          }
           this.misterSaveData = null;
         }
       } else {
@@ -389,7 +393,7 @@ export default {
         this.inputSegaCd = {};
       }
 
-      this.updateMisterSaveData();
+      this.updateMisterSaveData(inputSegaCdType);
     },
     convertFile() {
       let finalMisterSaveData = this.misterSaveData;

--- a/frontend/src/components/MisterPlatform.vue
+++ b/frontend/src/components/MisterPlatform.vue
@@ -64,7 +64,7 @@ export default {
         { value: 'Mister-SMS', text: 'Sega Master System' },
         { value: 'Mister-MD', text: 'Sega Genesis/Mega Drive' },
         { value: 'Mister-MCD', text: 'Sega CD/Mega CD' },
-        { value: 'Mister-SAT', text: 'Sega Saturn' },
+        // { value: 'Mister-SAT', text: 'Sega Saturn' }, // Reenable me to launch this feature
         // { value: 'Mister-32X', text: 'Sega 32X', disabled: true }, // Core currently does not support saving: https://github.com/MiSTer-devel/S32X_MiSTer
         // { value: 'Mister-DC', text: 'Dreamcast', disabled: true }, // MiSTer hardware not powerful enough
         { value: 'Mister-PCE', text: 'Turbografx-16/PC Engine' },

--- a/frontend/src/components/MisterPlatform.vue
+++ b/frontend/src/components/MisterPlatform.vue
@@ -64,14 +64,14 @@ export default {
         { value: 'Mister-SMS', text: 'Sega Master System' },
         { value: 'Mister-MD', text: 'Sega Genesis/Mega Drive' },
         { value: 'Mister-MCD', text: 'Sega CD/Mega CD' },
+        { value: 'Mister-SAT', text: 'Sega Saturn' },
         // { value: 'Mister-32X', text: 'Sega 32X', disabled: true }, // Core currently does not support saving: https://github.com/MiSTer-devel/S32X_MiSTer
-        // { value: 'Mister-SAT', text: 'Sega Saturn', disabled: true }, // Core is currently in development: https://github.com/srg320/Saturn_MiSTer
         // { value: 'Mister-DC', text: 'Dreamcast', disabled: true }, // MiSTer hardware not powerful enough
         { value: 'Mister-PCE', text: 'Turbografx-16/PC Engine' },
         { value: 'Mister-PS1', text: 'PlayStation 1' },
         // { value: 'Mister-PS2', text: 'PlayStation 2', disabled: true }, // MiSTer hardware not powerful enough
         { value: 'Mister-WS', text: 'WonderSwan/WonderSwan Color' },
-        // { value: 'Mister-AJ', text: 'Jaguar', disabled: true }, // Core is in early stages, saving may not be supported yet: https://github.com/Kitrinx/Jaguar_MiSTer (?)
+        // { value: 'Mister-AJ', text: 'Jaguar', disabled: true }, // Core is in early stages, saving may not be supported yet: https://github.com/MiSTer-devel/Jaguar_MiSTer
         // { value: 'Mister-AL', text: 'Lynx', disabled: true }, // No commercial releases for Lynx with saving. A few homebrews do, but saving not implmented on the MiSTer core: https://github.com/MiSTer-devel/AtariLynx_MiSTer
       ],
     };

--- a/frontend/src/components/SegaCdSaveTypeSelector.vue
+++ b/frontend/src/components/SegaCdSaveTypeSelector.vue
@@ -47,12 +47,20 @@ export default {
       set(newValue) { this.$emit('change', newValue); },
     },
   },
+  watch: {
+    ramCartText: {
+      immediate: true,
+      handler(newValue) {
+        this.options = [
+          { value: 'internal-memory', text: this.internalMemoryText },
+          { value: 'ram-cart', text: newValue },
+        ];
+      },
+    },
+  },
   data() {
     return {
-      options: [
-        { value: 'internal-memory', text: this.internalMemoryText },
-        { value: 'ram-cart', text: this.ramCartText },
-      ],
+      options: null,
     };
   },
 };

--- a/frontend/src/save-formats/Mister/SegaCd.js
+++ b/frontend/src/save-formats/Mister/SegaCd.js
@@ -34,7 +34,7 @@ export default class MisterSegaCdSaveData {
   static createWithNewSize(misterSaveData, newSize) {
     // Just leave the mister data alone: it can't load anything other than the original 512kB ram cart size.
     // But other platforms/emulators may need a different ram cart size
-    const newRawRamCartArrayBuffer = SegaCdUtil.resize(misterSaveData.rawRamCartSaveArrayBuffer, newSize);
+    const newRawRamCartArrayBuffer = SegaCdUtil.resize(misterSaveData.rawCartSaveArrayBuffer, newSize);
 
     return new MisterSegaCdSaveData(misterSaveData.rawInternalSaveArrayBuffer, newRawRamCartArrayBuffer, misterSaveData.misterArrayBuffer);
   }
@@ -56,13 +56,13 @@ export default class MisterSegaCdSaveData {
     return new MisterSegaCdSaveData(SegaCdUtil.truncateToActualSize(misterArrayBuffer), SegaCdUtil.makeEmptySave(MisterSegaCdSaveData.RAM_CART_SIZE), misterArrayBuffer);
   }
 
-  static createFromRawData({ rawInternalSaveArrayBuffer = null, rawRamCartSaveArrayBuffer = null }) {
+  static createFromRawData({ rawInternalSaveArrayBuffer = null, rawCartSaveArrayBuffer = null }) {
     // We can output either a large (8kB + 512kB) save or a small (only 8kB) save depending on
     // whether we're passed an internal save buffer and/or a ram cart save buffer.
     // There are 4 cases, depending on which combination of raw file we are passed.
 
     let truncatedRawInternalSaveBuffer = null;
-    let truncatedRawRamCartSaveArrayBuffer = null;
+    let truncatedRawCartSaveArrayBuffer = null;
     let misterRamCartSaveArrayBuffer = null;
 
     if (rawInternalSaveArrayBuffer !== null) {
@@ -73,9 +73,9 @@ export default class MisterSegaCdSaveData {
       }
     }
 
-    if (rawRamCartSaveArrayBuffer !== null) {
-      truncatedRawRamCartSaveArrayBuffer = SegaCdUtil.truncateToActualSize(rawRamCartSaveArrayBuffer);
-      misterRamCartSaveArrayBuffer = SegaCdUtil.resize(truncatedRawRamCartSaveArrayBuffer, MisterSegaCdSaveData.RAM_CART_SIZE);
+    if (rawCartSaveArrayBuffer !== null) {
+      truncatedRawCartSaveArrayBuffer = SegaCdUtil.truncateToActualSize(rawCartSaveArrayBuffer);
+      misterRamCartSaveArrayBuffer = SegaCdUtil.resize(truncatedRawCartSaveArrayBuffer, MisterSegaCdSaveData.RAM_CART_SIZE);
     }
 
     // Now that we've got our pieces resized and ready, we can see what we've got and figure out
@@ -84,7 +84,7 @@ export default class MisterSegaCdSaveData {
     if (truncatedRawInternalSaveBuffer !== null) {
       if (misterRamCartSaveArrayBuffer !== null) {
         // We have both pieces, so we're creating a large mister file
-        return new MisterSegaCdSaveData(truncatedRawInternalSaveBuffer, truncatedRawRamCartSaveArrayBuffer, Util.concatArrayBuffers([truncatedRawInternalSaveBuffer, misterRamCartSaveArrayBuffer]));
+        return new MisterSegaCdSaveData(truncatedRawInternalSaveBuffer, truncatedRawCartSaveArrayBuffer, Util.concatArrayBuffers([truncatedRawInternalSaveBuffer, misterRamCartSaveArrayBuffer]));
       }
 
       // We have the internal save data but not the ram cart save data, so create a small mister file
@@ -96,7 +96,7 @@ export default class MisterSegaCdSaveData {
 
     if (misterRamCartSaveArrayBuffer !== null) {
       // We have only the ram cart data, so create a large mister file
-      return new MisterSegaCdSaveData(emptyInternalSaveBuffer, truncatedRawRamCartSaveArrayBuffer, Util.concatArrayBuffers([emptyInternalSaveBuffer, misterRamCartSaveArrayBuffer]));
+      return new MisterSegaCdSaveData(emptyInternalSaveBuffer, truncatedRawCartSaveArrayBuffer, Util.concatArrayBuffers([emptyInternalSaveBuffer, misterRamCartSaveArrayBuffer]));
     }
 
     // We were given neither an internal nor a ram cart save buffer, so return a small mister file
@@ -104,9 +104,9 @@ export default class MisterSegaCdSaveData {
   }
 
   // This constructor creates a new object from a binary representation of a MiSTer save data file
-  constructor(rawInternalSaveArrayBuffer, rawRamCartSaveArrayBuffer, misterArrayBuffer) {
+  constructor(rawInternalSaveArrayBuffer, rawCartSaveArrayBuffer, misterArrayBuffer) {
     this.rawInternalSaveArrayBuffer = rawInternalSaveArrayBuffer;
-    this.rawRamCartSaveArrayBuffer = rawRamCartSaveArrayBuffer;
+    this.rawCartSaveArrayBuffer = rawCartSaveArrayBuffer;
     this.misterArrayBuffer = misterArrayBuffer;
   }
 
@@ -116,7 +116,7 @@ export default class MisterSegaCdSaveData {
         return this.rawInternalSaveArrayBuffer;
 
       case MisterSegaCdSaveData.RAM_CART:
-        return this.rawRamCartSaveArrayBuffer;
+        return this.rawCartSaveArrayBuffer;
 
       default:
         throw new Error(`Unknown index: ${index}`);

--- a/frontend/src/save-formats/Mister/SegaSaturn.js
+++ b/frontend/src/save-formats/Mister/SegaSaturn.js
@@ -38,12 +38,12 @@ export default class MisterSegaSaturnSaveData {
     return 'sav';
   }
 
-  static getRawFileExtension() {
-    return 'bkr';
+  static getRawFileExtension(saveType) {
+    return (saveType === 'internal-memory') ? 'bkr' : 'bcr';
   }
 
   static adjustOutputSizesPlatform() {
-    return 'segasaturn';
+    return null; // The internal and cart sizes are fixed
   }
 
   static createWithNewSize(/* misterSaveData, newSize */) {

--- a/frontend/tests/unit/save-formats/Mister/SegaCd.spec.js
+++ b/frontend/tests/unit/save-formats/Mister/SegaCd.spec.js
@@ -44,20 +44,20 @@ describe('MiSTer - Sega CD save format', () => {
   });
 
   it('should convert a raw RAM cart Sega CD save to the long MiSTer format', async () => {
-    const rawRamCartSaveArrayBuffer = await ArrayBufferUtil.readArrayBuffer(RAW_RAM_CART_FILENAME);
+    const rawCartSaveArrayBuffer = await ArrayBufferUtil.readArrayBuffer(RAW_RAM_CART_FILENAME);
     const misterArrayBuffer = await ArrayBufferUtil.readArrayBuffer(MISTER_COMBINED_RAM_CART_PLUS_EMPTY_INTERNAL_FILENAME);
 
-    const misterSegaCdSaveData = MisterSegaCdSaveData.createFromRawData({ rawRamCartSaveArrayBuffer });
+    const misterSegaCdSaveData = MisterSegaCdSaveData.createFromRawData({ rawCartSaveArrayBuffer });
 
     expect(ArrayBufferUtil.arrayBuffersEqual(misterSegaCdSaveData.getMisterArrayBuffer(), misterArrayBuffer)).to.equal(true);
   });
 
   it('should convert a raw internal save + raw RAM cart Sega CD save to the long MiSTer format', async () => {
     const rawInternalSaveArrayBuffer = await ArrayBufferUtil.readArrayBuffer(RAW_INTERNAL_FILENAME);
-    const rawRamCartSaveArrayBuffer = await ArrayBufferUtil.readArrayBuffer(RAW_RAM_CART_FILENAME);
+    const rawCartSaveArrayBuffer = await ArrayBufferUtil.readArrayBuffer(RAW_RAM_CART_FILENAME);
     const misterArrayBuffer = await ArrayBufferUtil.readArrayBuffer(MISTER_COMBINED_INTERNAL_PLUS_RAM_CART_FILENAME);
 
-    const misterSegaCdSaveData = MisterSegaCdSaveData.createFromRawData({ rawInternalSaveArrayBuffer, rawRamCartSaveArrayBuffer });
+    const misterSegaCdSaveData = MisterSegaCdSaveData.createFromRawData({ rawInternalSaveArrayBuffer, rawCartSaveArrayBuffer });
 
     expect(ArrayBufferUtil.arrayBuffersEqual(misterSegaCdSaveData.getMisterArrayBuffer(), misterArrayBuffer)).to.equal(true);
   });


### PR DESCRIPTION
- Added Saturn to the MiSTer UI (currently disabled until we launch)
- Able to change the display name for the cart in `SegaCdSaveTypeSelector` by changing its prop whenever
- Improved (but not properly fixed) bug where wrong/confusing error message displayed when selecting incorrect data when creating a MiSTer segacd/saturn file
  - Real fix would be more involved. No one has reported this yet and the impact doesn't seem too bad
- Renamed `rawRamCartSaveArrayBuffer` to `rawCartSaveArrayBuffer` in the MiSTer Sega CD code for consistency with the MiSTer Saturn code