### PR TITLE
Enable Saturn in the nav and on the MiSTer page

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -53,7 +53,6 @@
           <router-link to="/ps1/emulator">PS1{{'\xa0'}}-{{'\xa0'}}emulator</router-link>
         </b-col>
       </b-row>
-      <!--
       <b-row>
         <b-col class="nav-row">
           <router-link to="/sega-saturn/saroo">Sega{{'\xa0'}}Saturn{{'\xa0'}}-{{'\xa0'}}Saroo{{'\xa0'}}<span class="new-text">(New)</span></router-link> |
@@ -63,13 +62,6 @@
       </b-row>
       <b-row>
         <b-col class="nav-row">
-          <router-link to="/psp">PSP{{'\xa0'}}-{{'\xa0'}}Save{{'\xa0'}}decryption</router-link>
-        </b-col>
-      </b-row>
-      -->
-      <b-row>
-        <b-col class="nav-row">
-          <router-link to="/sega-cd">Sega{{'\xa0'}}CD</router-link> |
           <router-link to="/psp">PSP{{'\xa0'}}-{{'\xa0'}}Save{{'\xa0'}}decryption</router-link>
         </b-col>
       </b-row>

--- a/frontend/src/components/ConvertMister.vue
+++ b/frontend/src/components/ConvertMister.vue
@@ -216,7 +216,7 @@ export default {
       }
     },
     getSegaCdRawFileName() {
-      const filenameSuffix = (this.segaCdSaveType === 'internal-memory') ? ' - internal memory' : ' - ram cartridge';
+      const filenameSuffix = (this.segaCdSaveType === 'internal-memory') ? ' - internal memory' : ' - cartridge';
 
       return `${Util.removeFilenameExtension(this.inputFilename)}${filenameSuffix}.${this.misterPlatformClass.getRawFileExtension(this.segaCdSaveType)}`;
     },

--- a/frontend/src/components/ConvertSegaSaturnSaroo.vue
+++ b/frontend/src/components/ConvertSegaSaturnSaroo.vue
@@ -16,7 +16,8 @@
               :errorMessage="this.errorMessage"
               placeholderText="Choose a file to convert (*.BIN)"
               acceptExtension=".BIN"
-              :leaveRoomForHelpIcon="false"
+              :leaveRoomForHelpIcon="true"
+              helpText="Please select SS_SAVE.BIN, SS_MEMS.BIN, or SS_BUP.BIN from your Saroo"
             />
             <file-list
               :display="this.segaSaturnSaveData !== null"

--- a/frontend/src/components/MisterPlatform.vue
+++ b/frontend/src/components/MisterPlatform.vue
@@ -64,7 +64,7 @@ export default {
         { value: 'Mister-SMS', text: 'Sega Master System' },
         { value: 'Mister-MD', text: 'Sega Genesis/Mega Drive' },
         { value: 'Mister-MCD', text: 'Sega CD/Mega CD' },
-        // { value: 'Mister-SAT', text: 'Sega Saturn' }, // Reenable me to launch this feature
+        { value: 'Mister-SAT', text: 'Sega Saturn' },
         // { value: 'Mister-32X', text: 'Sega 32X', disabled: true }, // Core currently does not support saving: https://github.com/MiSTer-devel/S32X_MiSTer
         // { value: 'Mister-DC', text: 'Dreamcast', disabled: true }, // MiSTer hardware not powerful enough
         { value: 'Mister-PCE', text: 'Turbografx-16/PC Engine' },


### PR DESCRIPTION
- Enable links to Saturn pages in the nav
- Enable Saturn option on the MiSTer page
- Couple last-minute UI tweaks:
  - Added extra help for selecting a Saroo file
  - Rename cartridge saves on MiSTer page to more generic name for Sega CD/Saturn