### PR TITLE
Added check for non-zero data in trunacted PCE saves from the Wii

### DIFF
--- a/frontend/src/save-formats/Wii/ConvertFromPcEngine.js
+++ b/frontend/src/save-formats/Wii/ConvertFromPcEngine.js
@@ -107,6 +107,11 @@ export default (arrayBuffer) => {
   const outputDataView = new DataView(outputArrayBuffer);
   outputDataView.setUint16(POINTER_TO_FIRST_BYTE_AFTER_BRAM_OFFSET, BRAM_MEMORY_ADDRESS + BRAM_SIZE, LITTLE_ENDIAN);
 
+  const truncatedSaveData = outputArrayBuffer.slice(BRAM_SIZE);
+  if (!Util.allBytesEqual(truncatedSaveData, 0x00)) {
+    throw new Error('Attempting to truncate save that contains extra data');
+  }
+
   return {
     saveData: outputArrayBuffer.slice(0, BRAM_SIZE),
     fileExtension: 'sav',

--- a/frontend/src/util/util.js
+++ b/frontend/src/util/util.js
@@ -225,6 +225,14 @@ export default class Util {
     return (unequalIndex === undefined);
   }
 
+  static allBytesEqual(arrayBuffer, value) {
+    const u8 = new Uint8Array(arrayBuffer);
+
+    const unequalIndex = u8.find((element) => element !== value);
+
+    return (unequalIndex === undefined);
+  }
+
   static copyHeaderFromArrayBuffer(sourceArrayBuffer, headerByteCount, destinationArrayBuffer) {
     const headerArrayBuffer = sourceArrayBuffer.slice(0, headerByteCount);
     return Util.concatArrayBuffers([headerArrayBuffer, destinationArrayBuffer]);


### PR DESCRIPTION
Fixes https://github.com/euan-forrester/save-file-converter/issues/144