### PR TITLE
Fixed intermittent build errors caused by reading and writing the same file simultaneously

### DIFF
--- a/frontend/tests/unit/save-formats/FlashCarts/Genesis/MegaSD/32X.spec.js
+++ b/frontend/tests/unit/save-formats/FlashCarts/Genesis/MegaSD/32X.spec.js
@@ -43,8 +43,6 @@ describe('Flash cart - Genesis - Mega SD - 32X', () => {
     const flashCartSaveData = GenesisMegaSd32xFlashCartSaveData.createFromFlashCartData(flashCartArrayBuffer);
 
     expect(ArrayBufferUtil.arrayBuffersEqual(flashCartSaveData.getRawArrayBuffer(), rawArrayBuffer)).to.equal(true);
-
-    ArrayBufferUtil.writeArrayBuffer(MEGA_SD_RAW_NEW_FRAM_FILENAME, flashCartSaveData.getRawArrayBuffer());
   });
 
   it('should convert a raw FRAM save back to the Mega SD new style', async () => {

--- a/frontend/tests/unit/save-formats/FlashCarts/Genesis/MegaSD/Genesis.spec.js
+++ b/frontend/tests/unit/save-formats/FlashCarts/Genesis/MegaSD/Genesis.spec.js
@@ -109,8 +109,6 @@ describe('Flash cart - Genesis - Mega SD - Genesis', () => {
     const flashCartSaveData = GenesisMegaSdGenesisFlashCartSaveData.createFromFlashCartData(flashCartArrayBuffer);
 
     expect(ArrayBufferUtil.arrayBuffersEqual(flashCartSaveData.getRawArrayBuffer(), rawArrayBuffer)).to.equal(true);
-
-    ArrayBufferUtil.writeArrayBuffer(MEGA_SD_RAW_NEW_FRAM_FILENAME, flashCartSaveData.getRawArrayBuffer());
   });
 
   it('should convert a raw FRAM save to the new style', async () => {

--- a/frontend/tests/unit/save-formats/N64/DexDrive.spec.js
+++ b/frontend/tests/unit/save-formats/N64/DexDrive.spec.js
@@ -119,8 +119,6 @@ describe('N64 - DexDrive save format', () => {
     expect(dexDriveSaveData.getSaveFiles()[0].regionName).to.equal('North America');
     expect(dexDriveSaveData.getSaveFiles()[0].media).to.equal('N');
     expect(ArrayBufferUtil.arrayBuffersEqual(dexDriveSaveData.getSaveFiles()[0].rawData, rawNoteArrayBuffer)).to.equal(true);
-
-    ArrayBufferUtil.writeArrayBuffer(RAW_COMMENT_NOTE_FILENAME, dexDriveSaveData.getSaveFiles()[0].rawData);
   });
 
   it('should convert a file containing two saves that are 27 and 20 pages', async () => {

--- a/frontend/tests/unit/save-formats/PSP/Executable.spec.js
+++ b/frontend/tests/unit/save-formats/PSP/Executable.spec.js
@@ -59,8 +59,6 @@ describe('PSP executable decryption', function () { // eslint-disable-line func-
 
       const pspExecutable = PspExecutable.createFromEncryptedData(encryptedArrayBuffer);
 
-      ArrayBufferUtil.writeArrayBuffer(FINAL_FANTASY_TACTICS_UNENCRYPTED_EXECUTABLE_FILENAME, pspExecutable.getUnencryptedArrayBuffer());
-
       expect(ArrayBufferUtil.arrayBuffersEqual(pspExecutable.getUnencryptedArrayBuffer(), unencryptedArrayBuffer)).to.equal(true);
       expect(pspExecutable.getExecutableInfo().compressionAttributes).to.equal(2);
       expect(pspExecutable.getExecutableInfo().elfSize).to.equal(3835044);
@@ -80,8 +78,6 @@ describe('PSP executable decryption', function () { // eslint-disable-line func-
 
       const pspExecutable = PspExecutable.createFromEncryptedData(encryptedArrayBuffer);
 
-      ArrayBufferUtil.writeArrayBuffer(MEGA_MAN_UNENCRYPTED_EXECUTABLE_FILENAME, pspExecutable.getUnencryptedArrayBuffer());
-
       expect(ArrayBufferUtil.arrayBuffersEqual(pspExecutable.getUnencryptedArrayBuffer(), unencryptedArrayBuffer)).to.equal(true);
       expect(pspExecutable.getExecutableInfo().compressionAttributes).to.equal(0);
       expect(pspExecutable.getExecutableInfo().elfSize).to.equal(2293524);
@@ -100,8 +96,6 @@ describe('PSP executable decryption', function () { // eslint-disable-line func-
       const unencryptedArrayBuffer = await ArrayBufferUtil.readArrayBuffer(NEED_FOR_SPEED_UNENCRYPTED_EXECUTABLE_FILENAME);
 
       const pspExecutable = PspExecutable.createFromEncryptedData(encryptedArrayBuffer);
-
-      ArrayBufferUtil.writeArrayBuffer(NEED_FOR_SPEED_UNENCRYPTED_EXECUTABLE_FILENAME, pspExecutable.getUnencryptedArrayBuffer());
 
       expect(ArrayBufferUtil.arrayBuffersEqual(pspExecutable.getUnencryptedArrayBuffer(), unencryptedArrayBuffer)).to.equal(true);
       expect(pspExecutable.getExecutableInfo().compressionAttributes).to.equal(0);

--- a/frontend/tests/unit/save-formats/SegaSaturn/Emulators/yabasanshiro.spec.js
+++ b/frontend/tests/unit/save-formats/SegaSaturn/Emulators/yabasanshiro.spec.js
@@ -26,8 +26,7 @@ describe('Sega Saturn - yaba sanshiro', () => {
   });
 
   it('should create an empty internal memory file', async () => {
-    // const segaSaturnArrayBuffer = await ArrayBufferUtil.readArrayBuffer(EMPTY_INTERNAL_MEMORY_FILE_FILENAME);
-
+    const segaSaturnArrayBuffer = await ArrayBufferUtil.readArrayBuffer(EMPTY_INTERNAL_MEMORY_FILE_FILENAME);
     const segaSaturnSaveData = YabaSanshiroSegaSaturnSaveData.createFromSaveFiles([]);
 
     expect(segaSaturnSaveData.getVolumeInfo().blockSize).to.equal(0x40);
@@ -38,8 +37,6 @@ describe('Sega Saturn - yaba sanshiro', () => {
 
     expect(segaSaturnSaveData.getSaveFiles().length).to.equal(0);
 
-    // expect(ArrayBufferUtil.arrayBuffersEqual(segaSaturnSaveData.getArrayBuffer(), segaSaturnArrayBuffer)).to.equal(true);
-
-    ArrayBufferUtil.writeArrayBuffer(EMPTY_INTERNAL_MEMORY_FILE_FILENAME, segaSaturnSaveData.getArrayBuffer());
+    expect(ArrayBufferUtil.arrayBuffersEqual(segaSaturnSaveData.getArrayBuffer(), segaSaturnArrayBuffer)).to.equal(true);
   });
 });


### PR DESCRIPTION
I accidentally left in various calls to `writeArrayBuffer()` that I meant to remove before committing the code.

Recently I started seeing intermittent build errors happen, specifically in the Sega Genesis tests. They would only happen on the auto build and not on my local machine. It appears that they were because the same file was being read from and written to simultaneously.