### PR TITLE
Minor typo fixes

### DIFF
--- a/frontend/src/save-formats/N64/Components/NoteTable.js
+++ b/frontend/src/save-formats/N64/Components/NoteTable.js
@@ -35,7 +35,7 @@ function decodeString(uint8Array) {
   // but may as well make the output here match exactly just in case.
   const uint8ArrayFixup = uint8Array.slice();
 
-  const sum = uint8Array.reduce((accumulator, n) => accumulator + n);
+  const sum = uint8Array.reduce((accumulator, n) => accumulator + n, 0);
 
   // These indicate that something was corrupted in the file and needs manual fixing
   // This only seems to affect one entry: the publisher for Wave Race 64. We'll maintain this fixup for compatibility with https://github.com/bryc/mempak/blob/master/js/codedb.js

--- a/frontend/src/save-formats/N64/Mempack.js
+++ b/frontend/src/save-formats/N64/Mempack.js
@@ -105,8 +105,6 @@ export default class N64MempackSaveData {
 
     const totalSize = saveFiles.reduce((accumulator, x) => accumulator + x.rawData.byteLength, 0);
 
-    console.log(`Adding saves of total length ${totalSize} and max length is ${MAX_DATA_SIZE}`);
-
     if (totalSize > MAX_DATA_SIZE) {
       throw new Error(`These files are too large to fit in a single N64 Controller Pak: total size is ${totalSize} bytes, but max is ${MAX_DATA_SIZE}`);
     }

--- a/frontend/src/save-formats/PS1/Memcard.js
+++ b/frontend/src/save-formats/PS1/Memcard.js
@@ -97,7 +97,7 @@ function checkFile(file) {
 function xorAllBytes(arrayBuffer) {
   const array = new Uint8Array(arrayBuffer);
 
-  return array.reduce((acc, n) => acc ^ n);
+  return array.reduce((acc, n) => acc ^ n, 0);
 }
 
 function encodeFilename(filename, filenameTextEncoder) {
@@ -268,7 +268,7 @@ export default class Ps1MemcardSaveData {
 
     saveFiles.forEach((f) => checkFile(f));
 
-    const totalSize = saveFiles.reduce((total, f) => total + f.filesize);
+    const totalSize = saveFiles.reduce((total, f) => total + f.filesize, 0);
     if (totalSize > (NUM_BLOCKS * BLOCK_SIZE)) {
       throw new Error(`Total size of files is ${totalSize} bytes (${totalSize / BLOCK_SIZE} blocks) but max size is ${NUM_BLOCKS * BLOCK_SIZE} bytes (${NUM_BLOCKS} blocks)`);
     }


### PR DESCRIPTION
- Fixed missing second parameter to several calls to `reduce()`
- Removed `console.log()`