### PR TITLE
[Issue #343} Separate errors for SegaCD file types

### DIFF
--- a/frontend/src/components/ConvertMister.vue
+++ b/frontend/src/components/ConvertMister.vue
@@ -61,14 +61,14 @@
             <div v-if="this.isSegaCd">
               <input-file
                 @load="readEmulatorSaveData($event, 'rawInternalSaveArrayBuffer')"
-                :errorMessage="this.segaCdErrorMessage"
+                :errorMessage="this.segaCdInternalMemoryErrorMessage"
                 placeholderText="Choose an internal memory save file to convert"
                 :leaveRoomForHelpIcon="false"
                 ref="inputFileSegaCdInternalMemory"
               />
               <input-file
                 @load="readEmulatorSaveData($event, 'rawCartSaveArrayBuffer')"
-                :errorMessage="this.segaCdErrorMessage"
+                :errorMessage="this.segaCdRamCartridgeErrorMessage"
                 placeholderText="Choose a RAM cartridge save file to convert"
                 :leaveRoomForHelpIcon="false"
                 ref="inputFileSegaCdRamCart"
@@ -155,7 +155,8 @@ export default {
       misterPlatformPrevious: null,
       misterPlatformClass: null,
       errorMessage: null,
-      segaCdErrorMessage: null,
+      segaCdInternalMemoryErrorMessage: null,
+      segaCdRamCartridgeErrorMessage: null,
       outputFilename: null,
       outputFilesize: null,
       conversionDirection: 'convertToRaw',
@@ -200,7 +201,8 @@ export default {
       this.misterPlatformPrevious = null;
       this.misterPlatformClass = null;
       this.errorMessage = null;
-      this.segaCdErrorMessage = null;
+      this.segaCdInternalMemoryErrorMessage = null;
+      this.segaCdRamCartridgeErrorMessage = null;
       this.outputFilename = null;
       this.outputFilesize = null;
       this.inputArrayBuffer = null;
@@ -333,7 +335,8 @@ export default {
     },
     updateMisterSaveData(inputSegaCdType) {
       this.errorMessage = null;
-      this.segaCdErrorMessage = null;
+      this.segaCdInternalMemoryErrorMessage = null;
+      this.segaCdRamCartridgeErrorMessage = null;
       this.outputFilesize = null;
 
       if ((this.misterPlatformClass !== null) && (this.inputArrayBuffer !== null) && (this.inputFilename !== null) && (this.inputFileType !== null)) {
@@ -362,8 +365,10 @@ export default {
         } catch (e) {
           if (inputSegaCdType === null) {
             this.errorMessage = 'This file does not seem to be in the correct format';
-          } else {
-            this.segaCdErrorMessage = 'At least one of these files does not seem to be in the correct format';
+          } else if (inputSegaCdType === 'rawInternalSaveArrayBuffer') {
+            this.segaCdInternalMemoryErrorMessage = 'This internal memory save file does not seem to be in the correct format';
+          } else if (inputSegaCdType === 'rawCartSaveArrayBuffer') {
+            this.segaCdRamCartridgeErrorMessage = 'This RAM cartridge save file does not seem to be in the correct format';
           }
           this.misterSaveData = null;
         }


### PR DESCRIPTION
This is one way to address issue #343, by replacing the shared segaCdErrorMessage with distinct messages for each save type. Note that only the last submitted file type will have their error displayed.