### PR TITLE
Update python 3.9 -> 3.13 for build email lambda

### DIFF
--- a/terraform/dev/provider.tf
+++ b/terraform/dev/provider.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  region                  = var.region
-  version                 = "~> 5.20.1"
+  region = var.region
 }
 

--- a/terraform/dev/versions.tf
+++ b/terraform/dev/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 6.12"
     }
   }
 }

--- a/terraform/modules/build-common-infrastructure/logs-bucket.tf
+++ b/terraform/modules/build-common-infrastructure/logs-bucket.tf
@@ -1,21 +1,28 @@
 resource "aws_s3_bucket" "build_logs" {
   bucket        = "${var.build_logs_bucket}${var.bucketname_user_string}-${var.environment}"
   force_destroy = false == var.retain_build_logs_after_destroy
+}
 
-  lifecycle_rule {
-    id      = "expire-logs-after-N-days"
-    enabled = true
+resource "aws_s3_bucket_lifecycle_configuration" "build_logs" {
+  bucket = aws_s3_bucket.build_logs.id
 
-    prefix = "*"
+  rule {
+    id = "expire-logs-after-N-days"
+
+    filter {
+      prefix = "*"
+    }
 
     expiration {
       days = var.days_to_keep_build_logs
     }
+
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "build_logs" {
-  bucket = aws_s3_bucket.build_logs.id 
+  bucket = aws_s3_bucket.build_logs.id
 
   rule {
     apply_server_side_encryption_by_default {

--- a/terraform/modules/build-pipeline-frontend/email-logs.tf
+++ b/terraform/modules/build-pipeline-frontend/email-logs.tf
@@ -23,9 +23,12 @@ data "aws_iam_policy_document" "assume_role" {
 resource "aws_iam_role" "iam_for_lambda" {
   name               = "${var.lambda_function_name}-iam_for_lambda"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
 
-  inline_policy {
-    name = "email-logs-lambda-policy-${var.environment}"
+resource "aws_iam_role_policy" "iam_for_lambda_policy" {
+  name = "email-logs-lambda-policy-${var.environment}"
+  role = aws_iam_role.iam_for_lambda.id
+
     policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -72,7 +75,6 @@ resource "aws_iam_role" "iam_for_lambda" {
   ]
 }
 POLICY
-  }
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_events" {
@@ -98,7 +100,7 @@ resource "aws_lambda_function" "email_build_logs" {
 
   source_code_hash = data.archive_file.email_logs_lambda_function.output_base64sha256
 
-  runtime = "python3.9"
+  runtime = "python3.13"
 
   environment {
     variables = {

--- a/terraform/modules/frontend/s3.tf
+++ b/terraform/modules/frontend/s3.tf
@@ -19,7 +19,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "frontend" {
     filter {}
 
     noncurrent_version_expiration {
-      noncurrent_days = 90
+      noncurrent_days = var.days_to_keep_old_versions
     }
 
     status = "Enabled"

--- a/terraform/prod/provider.tf
+++ b/terraform/prod/provider.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  region                  = var.region
-  version                 = "~> 5.20.1"
+  region = var.region
 }
 

--- a/terraform/prod/versions.tf
+++ b/terraform/prod/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 6.12"
     }
   }
 }


### PR DESCRIPTION
- Python 3.9 is EOL, so updated to current stable version 3.13
- Had to update terrafrom `aws` provider to be able to specify python 3.13
- Fixed a bunch of deprecation warnings as a result of the provider update

Applied to dev and prod