### PR TITLE
Added fightingstreet.com to /download-saves, and removed blue swirl

### DIFF
--- a/frontend/src/views/DownloadSaves.vue
+++ b/frontend/src/views/DownloadSaves.vue
@@ -108,10 +108,10 @@
     <div class="blank-line"/>
     <b-row align-h="center">
       <b-col cols=12 md=5 lg=5 xl=4>
-        <b-link href="https://bswirl.kitsunet.org/vmu/save/public/index.php?lg=en&menu=on">Blue Swirl</b-link>
+        <b-link href="http://www.fightingstreet.com/folders/downloadsfolder/dreamcast/dreamcastsaves.html">Fighting Street</b-link>
       </b-col>
       <b-col cols=12 md=5 lg=5 xl=4>
-        Lots of Dreamcast games.
+        A small selection of Dreamcast games.
       </b-col>
     </b-row>
     <div class="blank-line"/>


### PR DESCRIPTION
Just discovered that fightingstreet.com hosts a few dreamcast saves

Blue swirl doesn't seem to have been up for a few years now, so removed it. Tested the remaining links and they all still work

Fixes https://github.com/euan-forrester/save-file-converter/issues/404