### PR TITLE
Write games to the beginning of the user area

### DIFF
--- a/frontend/src/save-formats/Dreamcast/Components/Basics.js
+++ b/frontend/src/save-formats/Dreamcast/Components/Basics.js
@@ -33,6 +33,8 @@ export default class DreamcastBasics {
 
   static DEFAULT_MAX_GAME_SIZE = 128;
 
+  static MAX_NUM_GAMES = 1;
+
   static FILE_TYPE_DATA = 'Data';
 
   static FILE_TYPE_GAME = 'Game';

--- a/frontend/src/save-formats/Dreamcast/Components/SystemInfo.js
+++ b/frontend/src/save-formats/Dreamcast/Components/SystemInfo.js
@@ -118,7 +118,7 @@ export default class DreamcastSystemInfo {
     dataView.setUint16(EXTRA_AREA_SIZE_IN_BLOCKS_OFFSET, DreamcastBasics.EXTRA_AREA_SIZE_IN_BLOCKS, LITTLE_ENDIAN);
 
     dataView.setUint16(GAME_BLOCK_OFFSET, DreamcastBasics.DEFAULT_GAME_BLOCK, LITTLE_ENDIAN);
-    dataView.setUint16(MAX_GAME_SIZE_OFFSET, DreamcastBasics.DEFAULT_MAX_GAME_SIZE, LITTLE_ENDIAN);
+    dataView.setUint16(MAX_GAME_SIZE_OFFSET, volumeInfo.maxGameSize, LITTLE_ENDIAN);
 
     return arrayBuffer;
   }


### PR DESCRIPTION
Game files must be written to the start of the user area and be contiguous, whereas data files are written to the end of the user area. We write them backwards, so they're not contiguous

In the system info block we set the max game size to be the biggest game written to the image or the default max of `128`, whichever is larger. Not sure what the most correct thing to do there is, but I figure that with the new vmu pro people may be creating homebrew games that are larger than the default max.