### PR TITLE
Fixed casing on rzipjs package to match new version on npm

### DIFF
--- a/frontend/src/util/CompressionRzip.js
+++ b/frontend/src/util/CompressionRzip.js
@@ -1,4 +1,4 @@
-import { RzipJS } from 'RzipJS';
+import { RzipJS } from 'rzipjs';
 
 import Util from './util';
 


### PR DESCRIPTION
It worked on my local machine but not in the autobuild